### PR TITLE
Allow custom library path

### DIFF
--- a/cf_spec/unit/buildpack/release/releaser_spec.rb
+++ b/cf_spec/unit/buildpack/release/releaser_spec.rb
@@ -112,7 +112,7 @@ doesn't matter for these tests
       end
 
       it 'set LD_LIBRARY_PATH in profile.d' do
-        expect(profile_d_script).to include('export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/libunwind/lib')
+        expect(profile_d_script).to include('export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/ld_library_path:$HOME/libunwind/lib')
       end
 
       it 'add Dotnet CLI to the PATH in profile.d' do
@@ -125,6 +125,16 @@ doesn't matter for these tests
 
       it "runs 'dotnet run' for project" do
         expect(web_process).to match('dotnet run --project foo')
+      end
+
+      context 'LD_LIBRARY_PATH specifies a custom library path' do
+        before do
+          ENV['LD_LIBRARY_PATH'] = '$HOME/my_custom_library/'
+        end
+
+        it 'appends the custom library path to LD_LIBRARY_PATH in profile.d' do
+          expect(profile_d_script).to include('export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/ld_library_path:$HOME/libunwind/lib:$HOME/my_custom_library/')
+        end
       end
     end
 

--- a/lib/buildpack/release/releaser.rb
+++ b/lib/buildpack/release/releaser.rb
@@ -38,6 +38,8 @@ module AspNetCoreBuildpack
         installers = AspNetCoreBuildpack::Installer.descendants
 
         library_path = get_library_path(installers)
+        custom_library_path = ENV['LD_LIBRARY_PATH']
+        library_path = "#{library_path}:#{custom_library_path}" if custom_library_path
         f.write "export LD_LIBRARY_PATH=#{library_path};"
 
         binary_path = get_binary_path(installers)
@@ -67,6 +69,7 @@ EOT
         subclass.new(@build_dir, @cache_dir, manifest_file, @shell).library_path
       end
       library_paths.insert(0, '$LD_LIBRARY_PATH')
+      library_paths.insert(1, '$HOME/ld_library_path')
       library_paths.compact.join(':')
     end
 


### PR DESCRIPTION
Some NuGet packages require that an external native library be installed on the system for the package to work properly, by allowing the user to add custom paths to the LD_LIBRARY_PATH variable we can enable users to package these native libraries with their application rather than needing to fork the buildpack and add an installer for these libraries.  For popular libraries, inclusion in the buildpack is still the preferred approach, but this method will also enable users to include proprietary native libraries with their applications as well.