### PR TITLE
Add F# support

### DIFF
--- a/cf_spec/unit/buildpack/detect/detect_spec.rb
+++ b/cf_spec/unit/buildpack/detect/detect_spec.rb
@@ -65,7 +65,28 @@ describe AspNetCoreBuildpack::Detecter do
         end
       end
 
-      context 'but no .cs file exists in the directory or sub directories' do
+      context 'and .fs file exists in the same directory' do
+        before do
+          File.open(File.join(dir, 'Program.fs'), 'w') { |f| f.write('a') }
+        end
+
+        it 'returns true' do
+          expect(subject.detect(dir)).to be_truthy
+        end
+      end
+
+      context 'and .fs file exists in a sub directory' do
+        before do
+          FileUtils.mkdir_p(File.join(dir, 'sub'))
+          File.open(File.join(dir, 'sub', 'Program.fs'), 'w') { |f| f.write('a') }
+        end
+
+        it 'returns true' do
+          expect(subject.detect(dir)).to be_truthy
+        end
+      end
+
+      context 'but no .cs or .fs file exists in the directory or sub directories' do
         it 'returns false' do
           expect(subject.detect(dir)).not_to be_truthy
         end
@@ -99,7 +120,28 @@ describe AspNetCoreBuildpack::Detecter do
         end
       end
 
-      context 'but no .cs file exists in the directory or sub directories' do
+      context 'and .fs file exists in the same directory' do
+        before do
+          File.open(File.join(dir, 'src', 'proj', 'Program.fs'), 'w') { |f| f.write('a') }
+        end
+
+        it 'returns true' do
+          expect(subject.detect(dir)).to be_truthy
+        end
+      end
+
+      context 'and .fs file exists in a sub directory' do
+        before do
+          FileUtils.mkdir_p(File.join(dir, 'src', 'proj', 'sub'))
+          File.open(File.join(dir, 'src', 'proj', 'sub', 'Program.fs'), 'w') { |f| f.write('a') }
+        end
+
+        it 'returns true' do
+          expect(subject.detect(dir)).to be_truthy
+        end
+      end
+
+      context 'but no .cs or .fs file exists in the directory or sub directories' do
         it 'returns false' do
           expect(subject.detect(dir)).not_to be_truthy
         end

--- a/lib/buildpack/detect/detecter.rb
+++ b/lib/buildpack/detect/detecter.rb
@@ -20,10 +20,9 @@ module AspNetCoreBuildpack
       fromsource = false
       arr = Dir.glob(File.join(dir, '**', 'project.json')).map { |file| File.dirname(file) }
       arr.each do |directory|
-        fromsource = !Dir.glob(File.join(directory, '*.cs')).empty? unless fromsource
-        fromsource = !Dir.glob(File.join(directory, '**', '*.cs')).empty? unless fromsource
+        fromsource = Dir.glob(File.join(directory, '**', '*.??')).grep(/.+\.(?:cs|fs)/).any? unless fromsource
       end
-      frompublish = !Dir.glob(File.join(dir, '*.runtimeconfig.json')).empty?
+      frompublish = Dir.glob(File.join(dir, '*.runtimeconfig.json')).any?
       fromsource || frompublish
     end
   end


### PR DESCRIPTION
Now that changes have been made to install additional .NET Frameworks, we can support the F# compiler in this buildpack as well.  This change looks for .fs or .cs files instead of just .cs files.  Once the VB.NET compiler works for .NET Core, we'll need to add that to the detect method as well (.vb files as well as .cs and .fs).