### PR TITLE
Store process id in a variable

### DIFF
--- a/cf_spec/unit/buildpack/release/releaser_spec.rb
+++ b/cf_spec/unit/buildpack/release/releaser_spec.rb
@@ -115,6 +115,10 @@ doesn't matter for these tests
         expect(profile_d_script).to include('export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/libunwind/lib')
       end
 
+      it 'set PID env variable in profile.d' do
+        expect(profile_d_script).to include('export PID=')
+      end
+
       it 'add Dotnet CLI to the PATH in profile.d' do
         expect(profile_d_script).to include('$HOME/.dotnet')
       end

--- a/lib/buildpack/release/releaser.rb
+++ b/lib/buildpack/release/releaser.rb
@@ -25,13 +25,13 @@ module AspNetCoreBuildpack
 
       raise 'No project could be identified to run' if start_cmd.nil? || start_cmd.empty?
 
-      write_startup_script(startup_script_path(build_dir))
+      write_startup_script(startup_script_path(build_dir), start_cmd)
       generate_yml(start_cmd)
     end
 
     private
 
-    def write_startup_script(startup_script)
+    def write_startup_script(startup_script, start_cmd)
       FileUtils.mkdir_p(File.dirname(startup_script))
       File.open(startup_script, 'w') do |f|
         f.write 'export HOME=/app;'
@@ -42,6 +42,8 @@ module AspNetCoreBuildpack
 
         binary_path = get_binary_path(installers)
         f.write "export PATH=#{binary_path};"
+
+        f.write "export PID=`ps -C '#{start_cmd}' -o pid= | tr -d '[:space:]'`"
       end
     end
 


### PR DESCRIPTION
Having easy access to the process id in an environment variable will be useful in remote debugging scenarios where this value needs to be passed to the debugger to attach.