### PR TITLE
Publish msbuild applications during staging

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,3 +15,5 @@ ParameterLists:
   Max: 9
 Metrics/AbcSize:
   Max: 30
+ClassLength:
+  Max: 150

--- a/cf_spec/fixtures/app_using_angular_msbuild/.profile
+++ b/cf_spec/fixtures/app_using_angular_msbuild/.profile
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-export PATH=$PATH:$HOME/src/app_using_angular/node_modules/.bin/:$HOME/src/app_using_angular

--- a/cf_spec/fixtures/app_using_angular_msbuild/manifest.yml
+++ b/cf_spec/fixtures/app_using_angular_msbuild/manifest.yml
@@ -6,3 +6,4 @@
       env:
         DOTNET_CLI_TELEMETRY_OPTOUT: 1
         CACHE_NUGET_PACKAGES: false
+        PUBLISH_RELEASE_CONFIG: true

--- a/cf_spec/fixtures/app_using_angular_msbuild/src/app_using_angular/Program.cs
+++ b/cf_spec/fixtures/app_using_angular_msbuild/src/app_using_angular/Program.cs
@@ -14,7 +14,7 @@ namespace app_using_angular
                           .AddCommandLine(args)
                           .Build();
 
-            var content_root = Path.Combine(Directory.GetCurrentDirectory(), "src", "app_using_angular");
+            var content_root = Directory.GetCurrentDirectory();
 
             var host = new WebHostBuilder()
                         .UseKestrel()

--- a/cf_spec/fixtures/app_using_angular_msbuild/src/app_using_angular/app_using_angular.csproj
+++ b/cf_spec/fixtures/app_using_angular_msbuild/src/app_using_angular/app_using_angular.csproj
@@ -9,9 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="**\*.cs" Exclude="wwwroot\**\*;node_modules;bin\**;obj\**;**\*.xproj;packages\**" />
-    <EmbeddedResource Include="**\*.resx" />
-    <EmbeddedResource Include="compiler\resources\**\*" />
+    <Compile Include="**\*.cs" Exclude="$(GlobalExclude)" />
+    <EmbeddedResource Include="**\*.resx" Exclude="$(GlobalExclude)" />
   </ItemGroup>
 
   <ItemGroup>
@@ -20,7 +19,7 @@
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Sdk.Web">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161104-2-112</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics">
@@ -60,7 +59,7 @@
       <Version>*</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.App">
-      <Version>1.0.1</Version>
+      <Version>1.0.3</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink.Loader">
       <Version>*</Version>
@@ -71,13 +70,27 @@
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
   </PropertyGroup>
 
-  <Target Name="PostcompileScript" AfterTargets="Build" Condition=" '$(IsCrossTargetingBuild)' != 'true' ">
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+
+  <Target Name="CustomCollectFiles" DependsOnTargets="BeforePublish">
+    <ItemGroup>
+      <Content Include="wwwroot/**/*;appsettings.json">
+        <CopyToPublishDirectory>Always</CopyToPublishDirectory>
+      </Content>
+    </ItemGroup>
+  </Target>
+  <PropertyGroup>
+    <AssignTargetPathsDependsOn>
+      CustomCollectFiles;
+      $(AssignTargetPathsDependsOn);
+    </AssignTargetPathsDependsOn>
+  </PropertyGroup>
+
+  <Target Name="BeforePublish">
     <Exec Command="npm install" />
     <Exec Command="bower install" />
     <Exec Command="gulp clean" />
     <Exec Command="gulp min" />
     <Exec Command="gulp copy-deps" />
   </Target>
-  
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/cf_spec/fixtures/app_using_angular_msbuild/src/app_using_angular/bower.json
+++ b/cf_spec/fixtures/app_using_angular_msbuild/src/app_using_angular/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "ASP.NET",
+  "name": "asp.net",
   "private": true,
   "dependencies": {
     "bootstrap": "3.3.5",

--- a/cf_spec/fixtures/msbuild_self_contained/Program.cs
+++ b/cf_spec/fixtures/msbuild_self_contained/Program.cs
@@ -1,0 +1,25 @@
+using System.IO;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+
+namespace HelloWeb
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+
+            var config = new ConfigurationBuilder()
+                          .AddCommandLine(args)
+                          .Build();
+            var host = new WebHostBuilder()
+                        .UseKestrel()
+                        .UseConfiguration(config)
+                        .UseContentRoot(Directory.GetCurrentDirectory())
+                        .UseStartup<Startup>()
+                        .Build();
+
+            host.Run();
+        }
+    }
+}

--- a/cf_spec/fixtures/msbuild_self_contained/Startup.cs
+++ b/cf_spec/fixtures/msbuild_self_contained/Startup.cs
@@ -1,0 +1,17 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+
+namespace HelloWeb
+{
+    public class Startup
+    {
+        public void Configure(IApplicationBuilder app)
+        {
+            app.Run(context =>
+            {
+                return context.Response.WriteAsync("Hello World!");
+            });
+        }
+    }
+}

--- a/cf_spec/fixtures/msbuild_self_contained/manifest.yml
+++ b/cf_spec/fixtures/msbuild_self_contained/manifest.yml
@@ -1,0 +1,6 @@
+---
+  applications:
+    - name: msbuild_self_contained
+      env:
+        DOTNET_CLI_TELEMETRY_OPTOUT: 1
+        CACHE_NUGET_PACKAGES: false

--- a/cf_spec/fixtures/msbuild_self_contained/msbuild_self_contained.csproj
+++ b/cf_spec/fixtures/msbuild_self_contained/msbuild_self_contained.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.Web" ToolsVersion="15.0">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <AssemblyName>msbuild_self_contained</AssemblyName>
+    <OutputType>Exe</OutputType>
+    <PackageId>msbuild_self_contained</PackageId>
+    <RuntimeIdentifier>ubuntu.14.04-x64</RuntimeIdentifier>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="*" />
+    <PackageReference Include="Microsoft.NETCore.App" Version="1.1.*" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="*" />
+  </ItemGroup>
+
+</Project>

--- a/cf_spec/fixtures/nancy_kestrel_web_app/manifest.yml
+++ b/cf_spec/fixtures/nancy_kestrel_web_app/manifest.yml
@@ -5,7 +5,6 @@ applications:
   memory: 1G
   instances: 1
   stack: cflinuxfs2
-  command: dotnet --verbose run --project . --server.urls http://0.0.0.0:$PORT --configuration Release
   env:
     DOTNET_CLI_TELEMETRY_OPTOUT: 1
     CACHE_NUGET_PACKAGES: false

--- a/cf_spec/fixtures/nancy_kestrel_web_app_msbuild/nancy_kestrel_web_app_msbuild.csproj
+++ b/cf_spec/fixtures/nancy_kestrel_web_app_msbuild/nancy_kestrel_web_app_msbuild.csproj
@@ -13,6 +13,9 @@
     <Compile Include="**\*.cs" />
     <EmbeddedResource Include="**\*.resx" />
     <EmbeddedResource Include="compiler\resources\**\*" />
+    <Content Include="appsettings.json">
+      <CopyToPublishDirectory>Always</CopyToPublishDirectory>
+    </Content>
   </ItemGroup>
 
   <ItemGroup>

--- a/cf_spec/integration/deploy_dotnetcore_app_spec.rb
+++ b/cf_spec/integration/deploy_dotnetcore_app_spec.rb
@@ -69,4 +69,17 @@ describe 'CF ASP.NET Core Buildpack' do
       expect(app).to use_proxy_during_staging
     end
   end
+
+  context 'deploying an msbuild app with RuntimeIdentfier' do
+    let(:app_name) { 'msbuild_self_contained' }
+
+    it 'displays a simple text homepage' do
+      expect(app).to be_running
+      expect(app).to have_logged(%r{Removing /tmp/app/\.dotnet})
+      expect(app).to have_logged(%r{started using .* \./msbuild_self_contained })
+
+      browser.visit_path('/')
+      expect(browser).to have_body('Hello World!')
+    end
+  end
 end

--- a/cf_spec/unit/buildpack/compile/compile_spec.rb
+++ b/cf_spec/unit/buildpack/compile/compile_spec.rb
@@ -202,13 +202,12 @@ describe AspNetCoreBuildpack::Compiler do
 
       context 'project is msbuild' do
         context 'published app is self-contained' do
-          let(:dotnet_sdk_installer) { AspNetCoreBuildpack::DotnetSdkInstaller.new(build_dir, cache_dir, 'manifest.yml', nil)}
-          let(:installer)            { double(:installer, descendants: [dotnet_sdk_installer]) }
 
           before do
-            allow(dotnet_sdk_installer).to receive(:should_restore).and_return(false)
-            allow(dotnet_sdk_installer).to receive(:self_contained_project?).and_return(true)
-            allow_any_instance_of(AspNetCoreBuildpack::DotnetFramework).to receive(:should_install?).and_return(false)
+            publish_dir = File.join(build_dir, '.cloudfoundry', 'dotnet_publish')
+            FileUtils.mkdir_p(publish_dir)
+            File.write(File.join(publish_dir, 'project_name'), 'xxx')
+            File.write(File.join(publish_dir, 'project_name.runtimeconfig.json'), 'xxx')
           end
 
           it 'removes the .dotnet, .node, and .nuget directories' do

--- a/cf_spec/unit/buildpack/compile/dotnet_cli_spec.rb
+++ b/cf_spec/unit/buildpack/compile/dotnet_cli_spec.rb
@@ -1,0 +1,133 @@
+$LOAD_PATH << 'cf_spec'
+require 'spec_helper'
+require 'rspec'
+require 'tmpdir'
+require 'fileutils'
+
+describe AspNetCoreBuildpack::DotnetCli do
+  let(:installers)        { [ double(:installer, path: '') ] }
+  let(:shell)             { AspNetCoreBuildpack.shell }
+  let(:out)               { double(:out) }
+  let(:build_dir)         { Dir.mktmpdir }
+  let(:project_paths)     { [] }
+  let(:main_project_path) { 'override' }
+  let(:app_dir)           { double(:app_dir, main_project_path: main_project_path,
+                                             project_paths: project_paths) }
+
+  subject { described_class.new(build_dir, installers) }
+
+  before do
+    allow(AspNetCoreBuildpack).to receive(:shell).and_return(shell)
+    allow(AspNetCoreBuildpack::AppDir).to receive(:new).with(build_dir).and_return(app_dir)
+    allow(shell).to receive(:exec)
+  end
+
+  after do
+    FileUtils.rm_rf(build_dir)
+  end
+
+  describe '#restore' do
+    context 'installed sdk uses msbuild' do
+      let(:project_paths) { %w(src/project1/project1.csproj src/project2/project2.csproj) }
+
+      before do
+        allow(subject).to receive(:msbuild?).with(build_dir).and_return(true)
+      end
+
+      it 'sets up the environent and runs dotnet restore once for each project' do
+        expect(shell).to receive(:exec) do |*args|
+          cmd = args.first
+          expect(cmd).to match(/dotnet restore src\/project1\/project1.csproj/)
+        end
+        expect(shell).to receive(:exec) do |*args|
+          cmd = args.first
+          expect(cmd).to match(/dotnet restore src\/project2\/project2.csproj/)
+        end
+
+        subject.restore(out)
+        expect(shell.env['HOME']).to eq build_dir
+        expect(shell.env['LD_LIBRARY_PATH']).to eq "$LD_LIBRARY_PATH:#{build_dir}/libunwind/lib"
+        path = "$PATH::#{build_dir}/src/project1/node_modules/.bin:#{build_dir}/src/project2/node_modules/.bin"
+        expect(shell.env['PATH']).to eq path
+      end
+    end
+
+    context 'installed sdk uses project.json' do
+      let(:project_paths) { %w(src/project1 src/project2) }
+
+      before do
+        allow(subject).to receive(:msbuild?).with(build_dir).and_return(false)
+      end
+
+      it 'sets up the environment and runs dotnet restore' do
+        expect(shell).to receive(:exec) do |*args|
+          cmd = args.first
+          expect(cmd).to match(/dotnet restore src\/project1 src\/project2/)
+        end
+
+        subject.restore(out)
+        expect(shell.env['HOME']).to eq build_dir
+        expect(shell.env['LD_LIBRARY_PATH']).to eq "$LD_LIBRARY_PATH:#{build_dir}/libunwind/lib"
+        path = "$PATH::#{build_dir}/src/project1/node_modules/.bin:#{build_dir}/src/project2/node_modules/.bin"
+        expect(shell.env['PATH']).to eq path
+      end
+    end
+  end
+
+  describe '#publish' do
+    context 'installed sdk uses msbuild' do
+      let(:main_project_path)      { 'src/project1/project1.csproj' }
+      let(:project_paths)          { %w(src/project1/project1.csproj) }
+      let(:publish_release_config) { 'override' }
+
+      before do
+        @old_env = ENV['PUBLISH_RELEASE_CONFIG']
+        ENV['PUBLISH_RELEASE_CONFIG'] = publish_release_config
+
+        allow(subject).to receive(:msbuild?).with(build_dir).and_return(true)
+      end
+
+      after do
+        ENV['PUBLISH_RELEASE_CONFIG'] = @old_env
+      end
+
+      context 'PUBLISH_RELEASE_CONFIG is true' do
+        let(:publish_release_config) { 'true' }
+
+        it 'sets up the environment, makes a directory to publish the app, and publishes it' do
+          publish_dir = File.join(build_dir, '.cloudfoundry', 'dotnet_publish')
+          expect(shell).to receive(:exec) do |*args|
+            cmd = args.first
+            expect(cmd).to match(/dotnet publish src\/project1\/project1.csproj -o #{publish_dir} -c Release/)
+          end
+
+          subject.publish(out)
+
+          expect(File.exist? publish_dir).to be_truthy
+          expect(shell.env['HOME']).to eq build_dir
+          expect(shell.env['LD_LIBRARY_PATH']).to eq "$LD_LIBRARY_PATH:#{build_dir}/libunwind/lib"
+          expect(shell.env['PATH']).to eq "$PATH::#{build_dir}/src/project1/node_modules/.bin"
+        end
+      end
+
+      context 'PUBLISH_RELEASE_CONFIG is not true' do
+        let(:publish_release_config) { nil }
+
+        it 'sets up the environment, makes a directory to publish the app, and publishes it' do
+          publish_dir = File.join(build_dir, '.cloudfoundry', 'dotnet_publish')
+          expect(shell).to receive(:exec) do |*args|
+            cmd = args.first
+            expect(cmd).to match(/dotnet publish src\/project1\/project1.csproj -o #{publish_dir} -c Debug/)
+          end
+
+          subject.publish(out)
+
+          expect(File.exist? publish_dir).to be_truthy
+          expect(shell.env['HOME']).to eq build_dir
+          expect(shell.env['LD_LIBRARY_PATH']).to eq "$LD_LIBRARY_PATH:#{build_dir}/libunwind/lib"
+          expect(shell.env['PATH']).to eq "$PATH::#{build_dir}/src/project1/node_modules/.bin"
+        end
+      end
+    end
+  end
+end

--- a/cf_spec/unit/buildpack/compile/installers/dotnet_sdk_installer_spec.rb
+++ b/cf_spec/unit/buildpack/compile/installers/dotnet_sdk_installer_spec.rb
@@ -24,9 +24,7 @@ describe AspNetCoreBuildpack::DotnetSdkInstaller do
   let(:shell) { double(:shell, env: {}) }
   let(:out) { double(:out) }
   let(:self_contained_app_dir) { double(:self_contained_app_dir, published_project: 'project1') }
-  let(:project_paths) { %w(project1 project2) }
-  let(:app_dir) { double(:app_dir, published_project: false,
-                         project_paths: project_paths) }
+  let(:app_dir) { double(:app_dir, published_project: false) }
   let(:manifest_dir)  { Dir.mktmpdir }
   let(:manifest_file) { File.join(manifest_dir, 'manifest.yml') }
   let(:manifest_contents) do
@@ -105,67 +103,6 @@ doesn't matter for these tests
       expect(out).to receive(:print).with(/.NET SDK version: /)
       expect(subject).to receive(:write_version_file).with(anything)
       subject.install(out)
-    end
-  end
-
-  describe '#restore' do
-    context 'intalled sdk uses msbuild' do
-      let(:project_paths) { %w(src1/project1.csproj src2/project2.csproj) }
-
-      before do
-        allow(subject).to receive(:msbuild?).with(dir).and_return(true)
-      end
-
-      it 'runs dotnet restore and rewrites project.assets.json' do
-        expect(shell).to receive(:exec) do |*args|
-          cmd = args.first
-          expect(cmd).to match(/dotnet restore src1\/project1.csproj/)
-        end
-        expect(shell).to receive(:exec) do |*args|
-          cmd = args.first
-          expect(cmd).to match(/dotnet restore src2\/project2.csproj/)
-        end
-        expect(subject).to receive(:rewrite_project_assets_json).with(%w(src1/project1.csproj src2/project2.csproj))
-
-        subject.should_restore(app_dir)
-        subject.restore(out)
-      end
-    end
-
-    context 'installed sdk uses project.json ' do
-      before do
-        allow(subject).to receive(:msbuild?).with(dir).and_return(false)
-      end
-
-      it 'runs dotnet restore and does not rewrite project.assets.json' do
-        expect(shell).to receive(:exec) do |*args|
-          cmd = args.first
-          expect(cmd).to match(/dotnet restore project1 project2/)
-        end
-        expect(subject).not_to receive(:rewrite_project_assets_json)
-
-        subject.should_restore(app_dir)
-        subject.restore(out)
-      end
-    end
-  end
-
-  describe '#rewrite_project_assets_json' do
-    let(:csproj_files) { %w(src1/project1.csproj src2/project2.csproj) }
-
-    before do
-      FileUtils.mkdir_p(File.join(dir, 'src1', 'obj'))
-      FileUtils.mkdir_p(File.join(dir, 'src2', 'obj'))
-
-      File.write(File.join(dir, 'src1', 'obj', 'project.assets.json'), '/tmp/app/.nuget/packages/')
-      File.write(File.join(dir, 'src2', 'obj', 'project.assets.json'), '/tmp/app/.nuget/packages/')
-    end
-
-    it 'substitutes runtime nuget package dir for staging dir in all projects' do
-      subject.rewrite_project_assets_json(csproj_files)
-
-      expect(File.read(File.join(dir, 'src1', 'obj', 'project.assets.json'))).to eq '/app/.nuget/packages/'
-      expect(File.read(File.join(dir, 'src2', 'obj', 'project.assets.json'))).to eq '/app/.nuget/packages/'
     end
   end
 

--- a/lib/buildpack/compile/compiler.rb
+++ b/lib/buildpack/compile/compiler.rb
@@ -110,10 +110,11 @@ module AspNetCoreBuildpack
     end
 
     def generated_self_contained_project?
-      generated_app_dir = AppDir.new(File.join(@build_dir, '.cloudfoundry', 'dotnet_publish'))
-      project_name = generated_app_dir.published_project
-      return false unless project_name
-      File.exist? File.join(@build_dir, '.cloudfoundry', 'dotnet_publish', project_name)
+      Dir.chdir(@build_dir) do
+        project_name = AppDir.new(DotnetCli::PUBLISH_DIR).published_project
+        return false unless project_name
+        File.exist? File.join(DotnetCli::PUBLISH_DIR, project_name)
+      end
     end
 
     def clear_nuget_cache(_out)

--- a/lib/buildpack/compile/compiler.rb
+++ b/lib/buildpack/compile/compiler.rb
@@ -97,16 +97,23 @@ module AspNetCoreBuildpack
 
       directories_to_remove = %w(.node .nuget)
 
-      if @dotnet_sdk && @dotnet_sdk.self_contained_project?(@app_dir)
-        directories_to_remove.push '.dotnet'
-      end
+      directories_to_remove.push '.dotnet' if generated_self_contained_project?
 
       Dir.chdir(@build_dir) do
         directories_to_remove.each do |dir|
-          out.print("Removing #{File.join(@build_dir, dir)}")
+          dir = File.join(@build_dir, dir)
+          next unless File.exist?(dir)
+          out.print("Removing #{dir}")
           FileUtils.rm_rf(dir)
         end
       end
+    end
+
+    def generated_self_contained_project?
+      generated_app_dir = AppDir.new(File.join(@build_dir, '.cloudfoundry', 'dotnet_publish'))
+      project_name = generated_app_dir.published_project
+      return false unless project_name
+      File.exist? File.join(@build_dir, '.cloudfoundry', 'dotnet_publish', project_name)
     end
 
     def clear_nuget_cache(_out)

--- a/lib/buildpack/compile/dotnet_cli.rb
+++ b/lib/buildpack/compile/dotnet_cli.rb
@@ -20,6 +20,7 @@ require_relative '../app_dir'
 module AspNetCoreBuildpack
   class DotnetCli
     include SdkInfo
+    PUBLISH_DIR = File.join('.cloudfoundry', 'dotnet_publish')
 
     def initialize(build_dir, installers)
       @build_dir = build_dir
@@ -49,7 +50,7 @@ module AspNetCoreBuildpack
       main_project = @app_dir.main_project_path
       raise 'No project found to build' if main_project.nil?
 
-      publish_dir = File.join(@build_dir, '.cloudfoundry', 'dotnet_publish')
+      publish_dir = File.join(@build_dir, PUBLISH_DIR)
       FileUtils.mkdir_p(publish_dir)
 
       cmd = "bash -c 'cd #{@build_dir}; dotnet publish #{main_project} -o #{publish_dir} -c #{publish_config}'"

--- a/lib/buildpack/compile/dotnet_cli.rb
+++ b/lib/buildpack/compile/dotnet_cli.rb
@@ -1,0 +1,88 @@
+# Encoding: utf-8
+# ASP.NET Core Buildpack
+# Copyright 2014-2016 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative '../sdk_info'
+require_relative '../app_dir'
+
+module AspNetCoreBuildpack
+  class DotnetCli
+    include SdkInfo
+
+    def initialize(build_dir, installers)
+      @build_dir = build_dir
+      @installers = installers
+      @app_dir = AppDir.new(@build_dir)
+      @shell = AspNetCoreBuildpack.shell
+    end
+
+    def restore(out)
+      setup_shell_environment
+
+      if msbuild?(@build_dir)
+        @app_dir.project_paths.each do |project|
+          cmd = "bash -c 'cd #{@build_dir}; dotnet restore #{project}'"
+          @shell.exec(cmd, out)
+        end
+      else
+        project_list = @app_dir.project_paths.join(' ')
+        cmd = "bash -c 'cd #{@build_dir}; dotnet restore #{project_list}'"
+        @shell.exec(cmd, out)
+      end
+    end
+
+    def publish(out)
+      setup_shell_environment
+
+      main_project = @app_dir.main_project_path
+      raise 'No project found to build' if main_project.nil?
+
+      publish_dir = File.join(@build_dir, '.cloudfoundry', 'dotnet_publish')
+      FileUtils.mkdir_p(publish_dir)
+
+      cmd = "bash -c 'cd #{@build_dir}; dotnet publish #{main_project} -o #{publish_dir} -c #{publish_config}'"
+
+      @shell.exec(cmd, out)
+    end
+
+    private
+
+    def publish_config
+      if ENV['PUBLISH_RELEASE_CONFIG'] == 'true'
+        'Release'
+      else
+        'Debug'
+      end
+    end
+
+    def setup_shell_environment
+      project_dirs = @app_dir.project_paths.map do |project|
+        if msbuild?(@build_dir)
+          File.join(@build_dir, File.dirname(project))
+        else
+          File.join(@build_dir, project)
+        end
+      end
+
+      node_modules_paths = project_dirs.map do |dir|
+        File.join(dir, 'node_modules', '.bin')
+      end.compact.join(':')
+
+      @shell.env['HOME'] = @build_dir
+      @shell.env['LD_LIBRARY_PATH'] = "$LD_LIBRARY_PATH:#{@build_dir}/libunwind/lib"
+      @shell.env['PATH'] = "$PATH:#{@installers.map(&:path).compact.join(':')}:#{node_modules_paths}"
+    end
+  end
+end

--- a/lib/buildpack/release/releaser.rb
+++ b/lib/buildpack/release/releaser.rb
@@ -23,13 +23,20 @@ module AspNetCoreBuildpack
 
     def release(build_dir)
       @build_dir = build_dir
-      app = AppDir.new(build_dir)
+
+      app_root_dir = if File.exist?(File.join(@build_dir, '.cloudfoundry', 'dotnet_publish'))
+                       File.join('.cloudfoundry', 'dotnet_publish')
+                     else
+                       '.'
+                     end
+
+      app = AppDir.new(File.expand_path(File.join(@build_dir, app_root_dir)))
       start_cmd = get_start_cmd(app)
 
       raise 'No project could be identified to run' if start_cmd.nil? || start_cmd.empty?
 
       write_startup_script(startup_script_path(build_dir), start_cmd)
-      generate_yml(start_cmd)
+      generate_yml(start_cmd, app_root_dir)
     end
 
     private
@@ -38,7 +45,6 @@ module AspNetCoreBuildpack
       FileUtils.mkdir_p(File.dirname(startup_script))
       File.open(startup_script, 'w') do |f|
         f.write 'export HOME=/app;'
-        f.write 'export NugetPackageRoot=/app/.nuget/packages/;' if msbuild?(@build_dir)
         installers = AspNetCoreBuildpack::Installer.descendants
 
         library_path = get_library_path(installers)
@@ -53,11 +59,11 @@ module AspNetCoreBuildpack
       end
     end
 
-    def generate_yml(start_cmd)
+    def generate_yml(start_cmd, app_root_dir)
       yml = <<-EOT
 ---
 default_process_types:
-  web: #{start_cmd} --server.urls http://0.0.0.0:${PORT}
+  web: cd #{app_root_dir} && #{start_cmd} --server.urls http://0.0.0.0:${PORT}
 EOT
       yml
     end

--- a/lib/buildpack/release/releaser.rb
+++ b/lib/buildpack/release/releaser.rb
@@ -24,8 +24,8 @@ module AspNetCoreBuildpack
     def release(build_dir)
       @build_dir = build_dir
 
-      app_root_dir = if File.exist?(File.join(@build_dir, '.cloudfoundry', 'dotnet_publish'))
-                       File.join('.cloudfoundry', 'dotnet_publish')
+      app_root_dir = if File.exist?(File.join(@build_dir, DotnetCli::PUBLISH_DIR))
+                       DotnetCli::PUBLISH_DIR
                      else
                        '.'
                      end


### PR DESCRIPTION
- The app is published to .cloudfoundry/dotnet_publish
- project.json and pre-published apps are not affected
- Created DotnetCli class to run `dotnet restore` + `dotnet publish`
- Add ability to configure Debug/Release mode for publishing apps
(default is Debug to match local cli's behavior)

Signed-off-by: Sam Smith <sesmith177@gmail.com>
Signed-off-by: Keaty <kgross@pivotal.io>
Signed-off-by: Dave Goddard <dave@goddard.id.au>
Signed-off-by: Anna Thornton <athornton@pivotal.io>
