### PR TITLE
Add staging_task.log file

### DIFF
--- a/bin/compile.rb
+++ b/bin/compile.rb
@@ -1,0 +1,60 @@
+#!/usr/bin/env ruby
+# Encoding: utf-8
+# ASP.NET Core Buildpack
+# Copyright 2014-2016 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+$stdout.sync = true
+$stderr.sync = true
+$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+
+require 'buildpack'
+require 'open3'
+
+build_dir = ARGV[0]
+cache_dir = ARGV[1]
+deps_dir = ARGV[3]
+buildpack_dir = File.join(File.dirname(__FILE__), '..')
+
+version = File.read(File.join(buildpack_dir, 'VERSION')).strip
+puts "-----> Buildpack version #{version}"
+
+system("#{buildpack_dir}/compile-extensions/bin/check_buildpack_version #{buildpack_dir} #{cache_dir}")
+
+if deps_dir
+  stdout, stderr, status = Open3.capture3("#{buildpack_dir}/compile-extensions/bin/build_path_from_supply #{deps_dir}")
+
+  if status.exitstatus.nonzero?
+    puts "build_path_from_supply script failed: #{stdout} \n====\n #{stderr}"
+    exit 1
+  end
+
+  stdout.split("\n").each do |line|
+    var, val = line.split('=')
+    ENV[var] = val
+  end
+
+  stdout, stderr, status = Open3.capture3("#{buildpack_dir}/compile-extensions/bin/write_profiled_from_supply #{deps_dir} #{build_dir}")
+  if status.exitstatus.nonzero?
+    puts "write_profiled_from_supply failed: #{stdout} \n====\n #{stderr}"
+    exit 1
+  end
+end
+
+if AspNetCoreBuildpack.compile(build_dir, cache_dir)
+  system("#{buildpack_dir}/compile-extensions/bin/store_buildpack_metadata #{buildpack_dir} #{cache_dir}")
+  exit 0
+else
+  exit 1
+end

--- a/bin/detect
+++ b/bin/detect
@@ -1,7 +1,7 @@
-#!/usr/bin/env ruby
+#!/bin/bash
 # Encoding: utf-8
 # ASP.NET Core Buildpack
-# Copyright 2014-2016 the original author or authors.
+# Copyright 2017 the original author or authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,16 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-$stdout.sync = true
-$stderr.sync = true
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
-
-require 'buildpack'
-
-build_dir = ARGV[0]
-if AspNetCoreBuildpack.detect(build_dir)
-  puts "ASP.NET Core (buildpack-#{AspNetCoreBuildpack::BuildpackVersion.new.version})"
-  exit 0
-else
-  exit 1
-end
+`dirname $0`/detect.rb "$@" | tee -a staging_task.log
+exit_status=${PIPESTATUS[0]}
+if [ $exit_status -ne 0 ]; then
+  exit $exit_status
+fi

--- a/bin/detect.rb
+++ b/bin/detect.rb
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env ruby
 # Encoding: utf-8
 # ASP.NET Core Buildpack
-# Copyright 2017 the original author or authors.
+# Copyright 2014-2016 the original author or authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,10 +15,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-`dirname $0`/compile.rb "$@" | tee -a staging_task.log
-exit_status=${PIPESTATUS[0]}
-if [ $exit_status -ne 0 ]; then
-  exit $exit_status
-fi
-mkdir -p $1/logs
-cp -f staging_task.log $1/logs/staging_task.log
+$stdout.sync = true
+$stderr.sync = true
+$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+
+require 'buildpack'
+
+build_dir = ARGV[0]
+if AspNetCoreBuildpack.detect(build_dir)
+  puts "ASP.NET Core (buildpack-#{AspNetCoreBuildpack::BuildpackVersion.new.version})"
+  exit 0
+else
+  exit 1
+end


### PR DESCRIPTION
Providing a staging_task.log file with all of the output from the staging process in the container after staging is completed.