### PR TITLE
do not remove any .NET Frameworks

### DIFF
--- a/cf_spec/unit/buildpack/compile/dotnet_framework_spec.rb
+++ b/cf_spec/unit/buildpack/compile/dotnet_framework_spec.rb
@@ -76,19 +76,12 @@ describe AspNetCoreBuildpack::DotnetFramework do
     context 'a version is installed that is not required' do
       let(:versions) { %w(5.5.5) }
 
-      before do
-        FileUtils.mkdir_p(File.join(dotnet_install_dir, 'shared', 'Microsoft.NETCore.App', '4.4.4'))
-      end
-
-      it 'installs the required version and removes the extra version' do
+      it 'installs the required version' do
         expect(out).to receive(:print).with("Downloading and installing .NET Core runtime 5.5.5")
         expect(shell).to receive(:exec).with(/download_dependency dotnet-framework.5.5.5.linux-amd64.tar.gz \/tmp/, out)
         expect(shell).to receive(:exec).with("mkdir -p #{dotnet_install_dir}; tar xzf /tmp/dotnet-framework.5.5.5.linux-amd64.tar.gz -C #{dotnet_install_dir}", out)
-        expect(out).to receive(:print).with("Removing .NET Core runtime 4.4.4")
 
         subject.install(out)
-
-        expect(File.exist?(File.join(dotnet_install_dir, 'shared', 'Microsoft.NETCore.App', '4.4.4'))).to eq false
       end
     end
   end

--- a/lib/buildpack/compile/dotnet_framework.rb
+++ b/lib/buildpack/compile/dotnet_framework.rb
@@ -41,8 +41,6 @@ module AspNetCoreBuildpack
         @shell.exec("#{buildpack_root}/compile-extensions/bin/warn_if_newer_patch #{dependency_name(version)} #{buildpack_root}/manifest.yml", out)
         @shell.exec("mkdir -p #{@dotnet_install_dir}; tar xzf /tmp/#{dependency_name(version)} -C #{@dotnet_install_dir}", out)
       end
-
-      clean_up_frameworks(out)
     end
 
     def name
@@ -54,15 +52,6 @@ module AspNetCoreBuildpack
     end
 
     private
-
-    def clean_up_frameworks(out)
-      frameworks_to_remove = installed_frameworks - versions
-
-      frameworks_to_remove.each do |version|
-        out.print("Removing .NET Core runtime #{version}")
-        FileUtils.rm_rf(File.join(@dotnet_install_dir, 'shared', 'Microsoft.NETCore.App', version))
-      end
-    end
 
     def installed_frameworks
       Dir.glob(File.join(@dotnet_install_dir, 'shared', 'Microsoft.NETCore.App', '*')).map do |path|


### PR DESCRIPTION
* Newer MSBuild SDKs rely on having one of the framework versions that was installed with them to remain in place in order to continue functioning, but that version may not be required for the application which caused it to sometimes be removed.
* Current solution is to skip the check for extra runtimes and only install new ones as required
