### PR TITLE
exclude nuget packages by environment variables

### DIFF
--- a/cf_spec/unit/buildpack/compile/finalize_spec.rb
+++ b/cf_spec/unit/buildpack/compile/finalize_spec.rb
@@ -203,7 +203,7 @@ describe AspNetCoreBuildpack::Finalizer do
 
         it 'copies files from cache to build dir' do
           allow(subject).to receive(:nuget_cache_is_valid?).and_return(true)
-          expect(copier).to receive(:cp).with(File.join(cache_dir, 'nuget'), build_dir, anything)
+          expect(copier).to receive(:cp).with(File.join(cache_dir, 'nuget'), File.join(deps_dir, deps_idx), anything)
           subject.finalize
         end
       end

--- a/lib/buildpack/compile/dotnet_cli.rb
+++ b/lib/buildpack/compile/dotnet_cli.rb
@@ -85,6 +85,9 @@ module AspNetCoreBuildpack
 
     def setup_shell_environment
       @shell.env['DOTNET_SKIP_FIRST_TIME_EXPERIENCE'] = 'true' if msbuild?
+      exclude_paths = []
+      exclude_paths << File.join('.cloudfoundry', '**', '*.*')
+      @shell.env['DefaultItemExcludes'] = exclude_paths.join(';') if msbuild?
 
       @shell.env['HOME'] = File.join(@deps_dir, @deps_idx)
       @shell.env['PATH'] = "#{ENV['PATH']}:#{node_modules_paths}"

--- a/lib/buildpack/compile/finalizer.rb
+++ b/lib/buildpack/compile/finalizer.rb
@@ -170,7 +170,7 @@ module AspNetCoreBuildpack
     end
 
     def restore_nuget_cache(out)
-      copier.cp(File.join(cache_dir, NUGET_CACHE_DIR), build_dir, out) if nuget_cache_is_valid?
+      copier.cp(File.join(cache_dir, NUGET_CACHE_DIR), File.join(@deps_dir, @deps_idx), out) if nuget_cache_is_valid?
     end
 
     def save_cache(out)


### PR DESCRIPTION
- Setting `DefaultItemExcludes` environment variable allows us to exclude the `.cloudfoundry` folder from both `dotnet restore` and `dotnet publish` commands without the need to copy the files to a temporary directory.
- Copying the NuGet Package to the dependencies directory instead of the main app directory resolves the issue that @dgodd saw when pushing an application for a 2nd time.