### PR TITLE
#174 - Fixed bug resolving project paths with multiple peroids in project name

### DIFF
--- a/src/dotnetcore/project/project.go
+++ b/src/dotnetcore/project/project.go
@@ -76,7 +76,7 @@ func (p *Project) MainPath() (string, error) {
 	if runtimeConfigFile, err := p.RuntimeConfigFile(); err != nil {
 		return "", err
 	} else if runtimeConfigFile != "" {
-		return runtimeConfigFile, nil
+		return strings.Replace(runtimeConfigFile, ".runtimeconfig.json", "", 1), nil
 	}
 	paths, err := p.Paths()
 	if err != nil {
@@ -84,7 +84,7 @@ func (p *Project) MainPath() (string, error) {
 	}
 
 	if len(paths) == 1 {
-		return paths[0], nil
+		return paths[0][0: strings.LastIndex(paths[0], ".")], nil
 	} else if len(paths) > 1 {
 		if exists, err := libbuildpack.FileExists(filepath.Join(p.buildDir, ".deployment")); err != nil {
 			return "", err
@@ -101,7 +101,8 @@ func (p *Project) MainPath() (string, error) {
 			if err != nil {
 				return "", err
 			}
-			return filepath.Join(p.buildDir, strings.Trim(project.String(), ".")), nil
+			trim := strings.Trim(project.String(), ".")
+			return filepath.Join(p.buildDir, trim[0: strings.LastIndex(trim, ".")]), nil
 		}
 		return "", fmt.Errorf("Multiple paths: %v contain a project file, but no .deployment file was used", paths)
 	}
@@ -145,5 +146,5 @@ func (p *Project) StartCommand() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return p.PublishedStartCommand(strings.Split(filepath.Base(projectPath), ".")[0])
+	return p.PublishedStartCommand(filepath.Base(projectPath))
 }

--- a/src/dotnetcore/project/project.go
+++ b/src/dotnetcore/project/project.go
@@ -122,8 +122,12 @@ func (p *Project) PublishedStartCommand(projectPath string) (string, error) {
 	} else {
 		publishedPath = filepath.Join(p.depDir, "dotnet_publish")
 		runtimePath = filepath.Join("${DEPS_DIR}", p.depsIdx, "dotnet_publish")
+
 		trim := strings.Trim(projectPath, ".")
-		command = trim[0: strings.LastIndex(trim, ".")]
+		if (strings.Contains(projectPath, ".")) {
+			command = trim[0: strings.LastIndex(trim, ".")]
+		}
+		command = trim
 	}
 
 	if exists, err := libbuildpack.FileExists(filepath.Join(publishedPath, command)); err != nil {

--- a/src/dotnetcore/project/project.go
+++ b/src/dotnetcore/project/project.go
@@ -124,7 +124,7 @@ func (p *Project) PublishedStartCommand(projectPath string) (string, error) {
 		runtimePath = filepath.Join("${DEPS_DIR}", p.depsIdx, "dotnet_publish")
 
 		trim := strings.Trim(projectPath, ".")
-		if (strings.Contains(projectPath, ".")) {
+		if (strings.Contains(trim, ".")) {
 			command = trim[0: strings.LastIndex(trim, ".")]
 		}
 		command = trim

--- a/src/dotnetcore/project/project_test.go
+++ b/src/dotnetcore/project/project_test.go
@@ -135,10 +135,10 @@ var _ = Describe("Project", func() {
 				Expect(ioutil.WriteFile(filepath.Join(buildDir, "fred.runtimeconfig.json"), []byte(""), 0644)).To(Succeed())
 			})
 
-			It("returns the runtimeconfig file without extension", func() {
+			It("returns the runtimeconfig file", func() {
 				configFile, err := subject.MainPath()
 				Expect(err).To(BeNil())
-				Expect(configFile).To(Equal(filepath.Join(buildDir, "fred")))
+				Expect(configFile).To(Equal(filepath.Join(buildDir, "fred.runtimeconfig.json")))
 			})
 		})
 		Context("No project path in paths", func() {
@@ -153,10 +153,10 @@ var _ = Describe("Project", func() {
 				Expect(os.MkdirAll(filepath.Dir(filepath.Join(buildDir, "subdir", "first.csproj")), 0755)).To(Succeed())
 				Expect(ioutil.WriteFile(filepath.Join(buildDir, "subdir", "first.csproj"), []byte(""), 0644)).To(Succeed())
 			})
-			It("returns that one path without extension", func() {
+			It("returns that one path", func() {
 				path, err := subject.MainPath()
 				Expect(err).To(BeNil())
-				Expect(path).To(Equal(filepath.Join("subdir", "first")))
+				Expect(path).To(Equal(filepath.Join("subdir", "first.csproj")))
 			})
 		})
 		Context("More than one project path in paths", func() {
@@ -179,10 +179,10 @@ var _ = Describe("Project", func() {
 				BeforeEach(func() {
 					Expect(ioutil.WriteFile(filepath.Join(buildDir, ".deployment"), []byte("[config]\nproject = ./a/b/first.vbproj"), 0644)).To(Succeed())
 				})
-				It("returns the path specified in the .deployment file without extension", func() {
+				It("returns the path specified in the .deployment file", func() {
 					path, err := subject.MainPath()
 					Expect(err).To(BeNil())
-					Expect(path).To(Equal(filepath.Join(buildDir, "a", "b", "first")))
+					Expect(path).To(Equal(filepath.Join(buildDir, "a", "b", "first.vbproj")))
 				})
 			})
 

--- a/src/dotnetcore/project/project_test.go
+++ b/src/dotnetcore/project/project_test.go
@@ -138,7 +138,7 @@ var _ = Describe("Project", func() {
 			It("returns the runtimeconfig file", func() {
 				configFile, err := subject.MainPath()
 				Expect(err).To(BeNil())
-				Expect(configFile).To(Equal(filepath.Join(buildDir, "fred.runtimeconfig.json")))
+				Expect(configFile).To(Equal(filepath.Join(buildDir, "fred")))
 			})
 		})
 		Context("No project path in paths", func() {
@@ -156,7 +156,7 @@ var _ = Describe("Project", func() {
 			It("returns that one path", func() {
 				path, err := subject.MainPath()
 				Expect(err).To(BeNil())
-				Expect(path).To(Equal(filepath.Join("subdir", "first.csproj")))
+				Expect(path).To(Equal(filepath.Join("subdir", "first")))
 			})
 		})
 		Context("More than one project path in paths", func() {
@@ -182,7 +182,7 @@ var _ = Describe("Project", func() {
 				It("returns the path specified in the .deployment file.", func() {
 					path, err := subject.MainPath()
 					Expect(err).To(BeNil())
-					Expect(path).To(Equal(filepath.Join(buildDir, "a", "b", "first.vbproj")))
+					Expect(path).To(Equal(filepath.Join(buildDir, "a", "b", "first")))
 				})
 			})
 

--- a/src/dotnetcore/project/project_test.go
+++ b/src/dotnetcore/project/project_test.go
@@ -135,7 +135,7 @@ var _ = Describe("Project", func() {
 				Expect(ioutil.WriteFile(filepath.Join(buildDir, "fred.runtimeconfig.json"), []byte(""), 0644)).To(Succeed())
 			})
 
-			It("returns the runtimeconfig file", func() {
+			It("returns the runtimeconfig file without extension", func() {
 				configFile, err := subject.MainPath()
 				Expect(err).To(BeNil())
 				Expect(configFile).To(Equal(filepath.Join(buildDir, "fred")))
@@ -153,7 +153,7 @@ var _ = Describe("Project", func() {
 				Expect(os.MkdirAll(filepath.Dir(filepath.Join(buildDir, "subdir", "first.csproj")), 0755)).To(Succeed())
 				Expect(ioutil.WriteFile(filepath.Join(buildDir, "subdir", "first.csproj"), []byte(""), 0644)).To(Succeed())
 			})
-			It("returns that one path", func() {
+			It("returns that one path without extension", func() {
 				path, err := subject.MainPath()
 				Expect(err).To(BeNil())
 				Expect(path).To(Equal(filepath.Join("subdir", "first")))
@@ -179,7 +179,7 @@ var _ = Describe("Project", func() {
 				BeforeEach(func() {
 					Expect(ioutil.WriteFile(filepath.Join(buildDir, ".deployment"), []byte("[config]\nproject = ./a/b/first.vbproj"), 0644)).To(Succeed())
 				})
-				It("returns the path specified in the .deployment file.", func() {
+				It("returns the path specified in the .deployment file without extension", func() {
 					path, err := subject.MainPath()
 					Expect(err).To(BeNil())
 					Expect(path).To(Equal(filepath.Join(buildDir, "a", "b", "first")))


### PR DESCRIPTION
#174 - Proposed fix  

Thanks for contributing to the buildpack. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Moved the logic that gets the project path for the start command into the MainPath() function, allowing for different strategies to be applied for different project types.

* An explanation of the use cases your change solves
Allows more different logic when resolving the project path for different project types (prepublished etc.)

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have added an integration test
