### PR TITLE
Support location on service credentials on the Dynatrace hook

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/cloudfoundry/dotnet-core-buildpack
 
 require (
-	github.com/Dynatrace/libbuildpack-dynatrace v1.1.0
+	github.com/Dynatrace/libbuildpack-dynatrace v1.2.0
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/cloudfoundry/libbuildpack v0.0.0-20190307214535-cd9ee704eaa2
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Dynatrace/libbuildpack-dynatrace v1.1.0 h1:lOLaWdK4eeQiApBbCyD3R1Nzg9arFZf4047cqH93U8w=
 github.com/Dynatrace/libbuildpack-dynatrace v1.1.0/go.mod h1:TojYXsxk1r+TaVOTUOWKyX2hAOzbvb+BsQGxUZ8Cb2s=
+github.com/Dynatrace/libbuildpack-dynatrace v1.2.0 h1:zeY8bOdtDqrTDmSHmFgumaacqZx44BzkBBoos7kU8DI=
+github.com/Dynatrace/libbuildpack-dynatrace v1.2.0/go.mod h1:TojYXsxk1r+TaVOTUOWKyX2hAOzbvb+BsQGxUZ8Cb2s=
 github.com/Masterminds/semver v1.4.2 h1:WBLTQ37jOCzSLtXNdoo8bNM8876KhNqOKvrlGITgsTc=
 github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=

--- a/vendor/github.com/Dynatrace/libbuildpack-dynatrace/README.md
+++ b/vendor/github.com/Dynatrace/libbuildpack-dynatrace/README.md
@@ -25,12 +25,13 @@ The Hook will look for credentials in the configurations for existing services (
 
 We support the following configuration fields,
 
-| Key           | Type    | Description                                                                 | Required | Default         |
-| ------------- | ------- | --------------------------------------------------------------------------- | -------- | --------------- |
-| environmentid | string  | The ID for the Dynatrace environment.                                       | Yes      | N/A             |
-| apitoken      | string  | The API Token for the Dynatrace environment.                                | Yes      | N/A             |
-| apiurl        | string  | Overrides the default Dynatrace API URL to connect to.                      | No       | Default API URL |
-| skiperrors    | boolean | If true, the deployment doesn't fail if the Dynatrace agent download fails. | No       | false           |
+| Key           | Type    | Description                                                                                 | Required | Default         |
+| ------------- | ------- | ------------------------------------------------------------------------------------------- | -------- | --------------- |
+| environmentid | string  | The ID for the Dynatrace environment.                                                       | Yes      | N/A             |
+| apitoken      | string  | The API Token for the Dynatrace environment.                                                | Yes      | N/A             |
+| apiurl        | string  | Overrides the default Dynatrace API URL to connect to.                                      | No       | Default API URL |
+| skiperrors    | boolean | If true, the deployment doesn't fail if the Dynatrace agent download fails.                 | No       | false           |
+| location      | string  | If set, agent is configured to choose communication endpoints located at the field's value. | No       | empty           |
 
 For example,
 

--- a/vendor/github.com/Dynatrace/libbuildpack-dynatrace/hook.go
+++ b/vendor/github.com/Dynatrace/libbuildpack-dynatrace/hook.go
@@ -29,6 +29,7 @@ type credentials struct {
 	APIToken      string
 	APIURL        string
 	SkipErrors    bool
+	Location      string
 }
 
 // Hook implements libbuildpack.Hook. It downloads and install the Dynatrace PaaS OneAgent.
@@ -71,13 +72,22 @@ func (h *Hook) AfterCompile(stager *libbuildpack.Stager) error {
 
 	h.Log.Info("Dynatrace service credentials found. Setting up Dynatrace PaaS agent.")
 
+	// Get buildpack version and language
+
+	lang := stager.BuildpackLanguage()
+	ver, err := stager.BuildpackVersion()
+	if err != nil {
+		h.Log.Warning("Failed to get buildpack version: %v", err)
+		ver = "unknown"
+	}
+
 	// Download installer...
 
 	installerFilePath := filepath.Join(os.TempDir(), "paasInstaller.sh")
 	url := h.getDownloadURL(creds)
 
 	h.Log.Info("Downloading '%s' to '%s'", url, installerFilePath)
-	if err = h.download(url, installerFilePath); err != nil {
+	if err = h.download(url, installerFilePath, ver, lang); err != nil {
 		if creds.SkipErrors {
 			h.Log.Warning("Error during installer download, skipping installation")
 			return nil
@@ -141,18 +151,16 @@ func (h *Hook) AfterCompile(stager *libbuildpack.Stager) error {
 	h.Log.Debug("Setting LD_PRELOAD...")
 	extra += fmt.Sprintf("\nexport LD_PRELOAD=${HOME}/%s", agentLibPath)
 
+	if creds.Location != "" {
+		h.Log.Debug("Setting DT_LOCATION...")
+		extra += fmt.Sprintf("\nexport DT_LOCATION=${DT_LOCATION:-%s}", creds.Location)
+	}
+
 	// By default, OneAgent logs are printed to stderr. If the customer doesn't override this behavior through an
 	// environment variable, then we change the default output to stdout.
 	if os.Getenv("DT_LOGSTREAM") == "" {
 		h.Log.Debug("Setting DT_LOGSTREAM to stdout...")
 		extra += "\nexport DT_LOGSTREAM=stdout"
-	}
-
-	lang := stager.BuildpackLanguage()
-	ver, err := stager.BuildpackVersion()
-	if err != nil {
-		h.Log.Warning("Failed to get buildpack version: %v", err)
-		ver = "unknown"
 	}
 
 	h.Log.Debug("Preparing custom properties...")
@@ -204,6 +212,7 @@ func (h *Hook) getCredentials() *credentials {
 				APIToken:      queryString("apitoken"),
 				APIURL:        queryString("apiurl"),
 				SkipErrors:    queryString("skiperrors") == "true",
+				Location:      queryString("location"),
 			}
 
 			if creds.EnvironmentID != "" && creds.APIToken != "" {
@@ -228,8 +237,12 @@ func (h *Hook) getCredentials() *credentials {
 }
 
 // download gets url, and stores it as filePath, retrying a few more times if the downloads fail.
-func (h *Hook) download(url, filePath string) error {
+func (h *Hook) download(url, filePath string, buildPackVersion string, language string) error {
 	const baseWaitTime = 3 * time.Second
+
+	client := &http.Client{}
+	req, _ := http.NewRequest("GET", url, nil)
+	req.Header.Set("User-Agent", fmt.Sprintf("cf-%s-buildpack/%s", language, buildPackVersion))
 
 	out, err := os.Create(filePath)
 	if err != nil {
@@ -238,8 +251,8 @@ func (h *Hook) download(url, filePath string) error {
 	defer out.Close()
 
 	for i := 0; ; i++ {
-		var resp *http.Response
-		if resp, err = http.Get(url); err == nil {
+		resp, err := client.Do(req)
+		if err == nil {
 			// We truncate the file to make it empty, we also need to move the offset to the beginning. For errors
 			// here, these would be unexpected so we just fail the function without retrying.
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/Dynatrace/libbuildpack-dynatrace v1.1.0
+# github.com/Dynatrace/libbuildpack-dynatrace v1.2.0
 github.com/Dynatrace/libbuildpack-dynatrace
 # github.com/Masterminds/semver v1.4.2
 github.com/Masterminds/semver


### PR DESCRIPTION
We now support optional "location" config entry on the service credentials.

This is used to use appropriate connection endpoint when the agent connects to the Dynatrace environment.

For internal monitoring we set the UserAgent when downloading the agent.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have added an integration test
