### PR TITLE
Updating version for dotnet-runtime for 3.1.X

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -105,6 +105,14 @@ dependencies:
   - cflinuxfs3
   source: https://download.visualstudio.microsoft.com/download/pr/d00eaeea-6d7b-4e73-9d96-c0234ed3b665/0d25d9d1aeaebdeef01d15370d5cd22b/dotnet-runtime-3.1.5-linux-x64.tar.gz
   source_sha256: ae0a4e9a1e875b46d3201cdad2779572de1c12c0aae36688ae3c3978db319ff5
+- name: dotnet-runtime
+  version: 3.1.6
+  uri: https://buildpacks.cloudfoundry.org/dependencies/dotnet-runtime/dotnet-runtime_3.1.6_linux_x64_any-stack_40ad7c23.tar.xz
+  sha256: 40ad7c23660f947c5d187141372e5ff49b5409be23e5cb7359aa2726c2b0910a
+  cf_stacks:
+  - cflinuxfs3
+  source: https://download.visualstudio.microsoft.com/download/pr/7c2978aa-1a4c-4fb0-a7cd-1dbaf1ce405d/c54e21f55dfa49d2ccdb599fa2edb9ed/dotnet-runtime-3.1.6-linux-x64.tar.gz
+  source_sha256: 9642940ce157670f01de0d6f0c3882194045b9df7339d31b54b1c4695605ca68
 - name: dotnet-sdk
   version: 2.1.806
   uri: https://buildpacks.cloudfoundry.org/dependencies/dotnet-sdk/dotnet-sdk_2.1.806_linux_x64_any-stack_6f9c29da.tar.xz


### PR DESCRIPTION
This PR is made automatically by release engineering bot.