### PR TITLE
Update runtime to sdk mapping for 3.1.7

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -231,3 +231,6 @@ runtime_to_sdks:
 - runtime_version: 3.1.6
   sdks:
   - 3.1.302
+- runtime_version: 3.1.7
+  sdks:
+  - 3.1.401


### PR DESCRIPTION
[This page](https://dotnet.microsoft.com/download/dotnet-core/3.1) shows that runtime 3.1.7 is compatible with SDK 3.1.401

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have added an integration test
