### PR TITLE
Updating version for dotnet-runtime for 3.1.X

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -114,6 +114,14 @@ dependencies:
   source: https://download.visualstudio.microsoft.com/download/pr/a3575ea2-ce06-4002-8568-e887da3e3a4f/7991b9bb111edcd2114efc6fe3ebfabb/dotnet-runtime-3.1.11-linux-x64.tar.gz
   source_sha256: 8ff244b9e23bda79dbaba7823f9b738f3971700aeaa42a43e6f33156e6dd93f1
 - name: dotnet-runtime
+  version: 3.1.12
+  uri: https://buildpacks.cloudfoundry.org/dependencies/dotnet-runtime/dotnet-runtime_3.1.12_linux_x64_any-stack_92a72d2f.tar.xz
+  sha256: 92a72d2f3bf35fc3780c3095d7cc567e46880796fd6cb5975962d9a4977bdbe1
+  cf_stacks:
+  - cflinuxfs3
+  source: https://download.visualstudio.microsoft.com/download/pr/f54a9098-69e6-4914-8fa8-42cb4ed05e65/9daae40d4a0ea4ad7aa2fc014b5f20db/dotnet-runtime-3.1.12-linux-x64.tar.gz
+  source_sha256: 3c9fc21b409654f42f9718fdb699847db268c695a56ce15839487587285d2f88
+- name: dotnet-runtime
   version: 5.0.1
   uri: https://buildpacks.cloudfoundry.org/dependencies/dotnet-runtime/dotnet-runtime_5.0.1_linux_x64_any-stack_6784f2f4.tar.xz
   sha256: 6784f2f48a524fad34775743a5097598dc42742bbb8cb77232e9019a6b2b0b11


### PR DESCRIPTION
This PR is made automatically by release engineering bot.