### PR TITLE
Updating version for dotnet-runtime for 2.1.X

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -106,6 +106,14 @@ dependencies:
   source: https://download.visualstudio.microsoft.com/download/pr/5c00bafe-4ead-4e9a-82b6-884a9727e751/fdb7f6701e556d89b6884037cc9983cb/dotnet-runtime-2.1.26-linux-x64.tar.gz
   source_sha256: 2a7e4d28c9ab479570e5d351257796db8fa1d13a95092eeebf3934260b9a7a6e
 - name: dotnet-runtime
+  version: 2.1.27
+  uri: https://buildpacks.cloudfoundry.org/dependencies/dotnet-runtime/dotnet-runtime_2.1.27_linux_x64_any-stack_7f732294.tar.xz
+  sha256: 7f73229433859bbe1e383969e8db07ce8fef1ec1bea53507484fa606600fc66b
+  cf_stacks:
+  - cflinuxfs3
+  source: https://download.visualstudio.microsoft.com/download/pr/f7eb39c4-484d-4e01-bd41-b4fe6794cd82/ff5c2799f30ea6dd19964c5c90780dba/dotnet-runtime-2.1.27-linux-x64.tar.gz
+  source_sha256: 9d4e8c6c65939dd755e51e11f855f09c187d756b8bb6476ffb0419e539e57f5a
+- name: dotnet-runtime
   version: 3.1.12
   uri: https://buildpacks.cloudfoundry.org/dependencies/dotnet-runtime/dotnet-runtime_3.1.12_linux_x64_any-stack_92a72d2f.tar.xz
   sha256: 92a72d2f3bf35fc3780c3095d7cc567e46880796fd6cb5975962d9a4977bdbe1


### PR DESCRIPTION
This PR is made automatically by release engineering bot.