### PR TITLE
Updating version for dotnet-runtime for 3.1.X

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -109,6 +109,14 @@ dependencies:
   source: https://download.visualstudio.microsoft.com/download/pr/692284f9-e1e7-4b31-9191-cd8043441024/ac45c17d4327b1f992b7fe3956a99129/dotnet-runtime-3.1.15-linux-x64.tar.gz
   source_sha256: cf8017acab943d8ad048b5891bdd4acd041440ecfc5b468707cc7d987740098a
 - name: dotnet-runtime
+  version: 3.1.16
+  uri: https://buildpacks.cloudfoundry.org/dependencies/dotnet-runtime/dotnet-runtime_3.1.16_linux_x64_any-stack_b256d9fa.tar.xz
+  sha256: b256d9fa93a3a7b2d69663f7f3c19040b582d1bd0338d1934b3f9330405fe44d
+  cf_stacks:
+  - cflinuxfs3
+  source: https://download.visualstudio.microsoft.com/download/pr/45774232-d104-4ef6-a22d-9412288c0062/4b6f2462a7ccc8899950a8641631d65d/dotnet-runtime-3.1.16-linux-x64.tar.gz
+  source_sha256: 6b638e51d5688c7c58859f9220e28576b381cad91b1aa12e6049fdb6f5ef4eea
+- name: dotnet-runtime
   version: 5.0.5
   uri: https://buildpacks.cloudfoundry.org/dependencies/dotnet-runtime/dotnet-runtime_5.0.5_linux_x64_any-stack_e4c3d01f.tar.xz
   sha256: e4c3d01f6eff1a442023841c309a4c8f2e9091eddb3bcefb4c7de98c7653a3ca


### PR DESCRIPTION
This PR is made automatically by release engineering bot.