### PR TITLE
Propagates errors from global.json SDK install

### DIFF
--- a/src/dotnetcore/integration/init_test.go
+++ b/src/dotnetcore/integration/init_test.go
@@ -111,6 +111,8 @@ func TestIntegration(t *testing.T) {
 }
 
 func PushAppAndConfirm(t *testing.T, app *cutlass.App) {
+	t.Helper()
+
 	var (
 		Expect     = NewWithT(t).Expect
 		Eventually = NewWithT(t).Eventually
@@ -122,12 +124,16 @@ func PushAppAndConfirm(t *testing.T, app *cutlass.App) {
 }
 
 func DestroyApp(t *testing.T, app *cutlass.App) *cutlass.App {
+	t.Helper()
+
 	var Expect = NewWithT(t).Expect
 	Expect(app.Destroy()).To(Succeed())
 	return nil
 }
 
 func GetLatestDepVersion(t *testing.T, dep, constraint, bpDir string) string {
+	t.Helper()
+
 	var Expect = NewWithT(t).Expect
 
 	manifest, err := libbuildpack.NewManifest(bpDir, nil, time.Now())
@@ -140,6 +146,8 @@ func GetLatestDepVersion(t *testing.T, dep, constraint, bpDir string) string {
 }
 
 func ReplaceFileTemplate(t *testing.T, pathToFixture, file, templateVar, replaceVal string) *cutlass.App {
+	t.Helper()
+
 	var Expect = NewWithT(t).Expect
 
 	dir, err := cutlass.CopyFixture(pathToFixture)

--- a/src/dotnetcore/supply/supply_test.go
+++ b/src/dotnetcore/supply/supply_test.go
@@ -353,11 +353,8 @@ var _ = Describe("Supply", func() {
 						mockManifest.EXPECT().AllDependencyVersions("dotnet-sdk").Return([]string{"1.1.1", "1.3.7"})
 					})
 
-					It("installs the default version", func() {
-						mockManifest.EXPECT().DefaultVersion("dotnet-sdk").Return(defaultDep, nil)
-						mockInstaller.EXPECT().InstallDependency(defaultDep, filepath.Join(depsDir, depsIdx, "dotnet-sdk"))
-
-						Expect(supplier.InstallDotnetSdk()).To(Succeed())
+					It("returns an error", func() {
+						Expect(supplier.InstallDotnetSdk()).To(MatchError("could not find sdk in same feature line as '1.2.3'"))
 					})
 				})
 			})
@@ -401,59 +398,6 @@ var _ = Describe("Supply", func() {
 				mockInstaller.EXPECT().InstallDependency(dep, filepath.Join(depsDir, depsIdx, "dotnet-sdk"))
 
 				Expect(supplier.InstallDotnetSdk()).To(Succeed())
-			})
-		})
-
-		Context("global.json", func() {
-			Context("with sdk/version", func() {
-				Context("that is in the buildpack", func() {
-					BeforeEach(func() {
-						Expect(ioutil.WriteFile(filepath.Join(buildDir, "global.json"), []byte(`{"sdk": {"version": "6.7.8"}}`), 0644)).To(Succeed())
-						mockManifest.EXPECT().AllDependencyVersions("dotnet-sdk").Return([]string{"6.7.8"})
-					})
-
-					It("installs the requested version", func() {
-						dep := libbuildpack.Dependency{Name: "dotnet-sdk", Version: "6.7.8"}
-						mockInstaller.EXPECT().InstallDependency(dep, filepath.Join(depsDir, depsIdx, "dotnet-sdk"))
-
-						Expect(supplier.InstallDotnetSdk()).To(Succeed())
-					})
-				})
-
-				Context("that is missing, but matches existing version lines", func() {
-					BeforeEach(func() {
-						Expect(ioutil.WriteFile(filepath.Join(buildDir, "global.json"), []byte(`{"sdk": {"version": "1.2.301"}}`), 0644)).To(Succeed())
-						mockManifest.EXPECT().AllDependencyVersions("dotnet-sdk").Return([]string{"1.1.113", "1.2.303", "1.2.608", "1.3.709"})
-					})
-
-					It("installs the latest of the same feature line", func() {
-						dep := libbuildpack.Dependency{Name: "dotnet-sdk", Version: "1.2.303"}
-						mockInstaller.EXPECT().InstallDependency(dep, filepath.Join(depsDir, depsIdx, "dotnet-sdk"))
-
-						Expect(supplier.InstallDotnetSdk()).To(Succeed())
-					})
-				})
-
-				Context("that is missing, and does not match existing version lines", func() {
-					BeforeEach(func() {
-						Expect(ioutil.WriteFile(filepath.Join(buildDir, "global.json"), []byte(`{"sdk": {"version": "1.2.3"}}`), 0644)).To(Succeed())
-						mockManifest.EXPECT().AllDependencyVersions("dotnet-sdk").Return([]string{"1.1.1", "1.3.7"})
-					})
-
-					It("installs the default version", func() {
-						mockManifest.EXPECT().DefaultVersion("dotnet-sdk").Return(defaultDep, nil)
-						mockInstaller.EXPECT().InstallDependency(defaultDep, filepath.Join(depsDir, depsIdx, "dotnet-sdk"))
-
-						Expect(supplier.InstallDotnetSdk()).To(Succeed())
-					})
-				})
-			})
-		})
-
-		Context("fsproj", func() {
-			BeforeEach(func() {
-				Expect(os.Mkdir(filepath.Join(buildDir, "inner"), 0755)).To(Succeed())
-				Expect(ioutil.WriteFile(filepath.Join(buildDir, "inner", "example.fsproj"), []byte(""), 0644)).To(Succeed())
 			})
 		})
 


### PR DESCRIPTION
Instead of ignoring the error and installing the default SDK, returns the error and stops staging. If the global.json is present, but does not contain an SDK version, the existing behavior is maintained (uses default SDK).

Also:
- Removes unused code
- Removes some duplicated tests
- Adds t.Helper() to some integration test utils for better debugging

* [x] I have viewed signed and have submitted the Contributor License Agreement
* [x] I have made this pull request to the `develop` branch
* [x] My changes are tested
