### PR TITLE
bumped libbuildpack-dynatrace to v1.4.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cloudfoundry/dotnet-core-buildpack
 go 1.16
 
 require (
-	github.com/Dynatrace/libbuildpack-dynatrace v1.4.1
+	github.com/Dynatrace/libbuildpack-dynatrace v1.4.2
 	github.com/Masterminds/semver v1.5.0
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/cloudfoundry/libbuildpack v0.0.0-20211012151659-ed6fb71f47bf

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,8 @@ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/Dynatrace/libbuildpack-dynatrace v1.4.1 h1:1IMG4xR/UgfcLxzCA/kRfZ05Tbx4MsHt1MDdkTEk/Ks=
-github.com/Dynatrace/libbuildpack-dynatrace v1.4.1/go.mod h1:TojYXsxk1r+TaVOTUOWKyX2hAOzbvb+BsQGxUZ8Cb2s=
+github.com/Dynatrace/libbuildpack-dynatrace v1.4.2 h1:sGmRK5owrhyryDSDkX6PjxUTPj+RAxyD5W1rMLX3S1A=
+github.com/Dynatrace/libbuildpack-dynatrace v1.4.2/go.mod h1:TojYXsxk1r+TaVOTUOWKyX2hAOzbvb+BsQGxUZ8Cb2s=
 github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=

--- a/vendor/github.com/Dynatrace/libbuildpack-dynatrace/hook.go
+++ b/vendor/github.com/Dynatrace/libbuildpack-dynatrace/hook.go
@@ -320,7 +320,7 @@ func (h *Hook) getDownloadURL(c *credentials) string {
 	qv.Add("bitness", "64")
 	// only set the networkzone property when it is configured
 	if c.NetworkZone != "" {
-		qv.Add("networkzone", c.NetworkZone)
+		qv.Add("networkZone", c.NetworkZone)
 	}
 	for _, t := range h.IncludeTechnologies {
 		qv.Add("include", t)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,6 +1,6 @@
 # code.cloudfoundry.org/lager v2.0.0+incompatible
 code.cloudfoundry.org/lager
-# github.com/Dynatrace/libbuildpack-dynatrace v1.4.1
+# github.com/Dynatrace/libbuildpack-dynatrace v1.4.2
 ## explicit
 github.com/Dynatrace/libbuildpack-dynatrace
 # github.com/Masterminds/semver v1.5.0


### PR DESCRIPTION
* A short explanation of the proposed change:
Bumped libbuildpack-dynatrace to v1.4.2 to make use of a bugfix in this library

* An explanation of the use cases your change solves
There was a bug in libbuildpack-dynatrace which used a miswritten query parameter when the `networkzones` property was set.
This didn't cause any deployment problems, but the feature wasn't used as intended.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have added an integration test