### PR TITLE
Bump github.com/Sealights/libbuildpack-sealights from 1.0.0 to 1.0.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/Dynatrace/libbuildpack-dynatrace v1.4.2
 	github.com/Masterminds/semver v1.5.0
-	github.com/Sealights/libbuildpack-sealights v1.0.0
+	github.com/Sealights/libbuildpack-sealights v1.0.1
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/cloudfoundry/libbuildpack v0.0.0-20220509111721-05ef1d6ca1f1
 	github.com/fsnotify/fsnotify v1.5.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF0
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
-github.com/Sealights/libbuildpack-sealights v1.0.0 h1:Xaq8fGvSqQht4ziY85DG6GajlX7MMtAiV/rUdVaB3CE=
-github.com/Sealights/libbuildpack-sealights v1.0.0/go.mod h1:ZX8o3uDgAa4zacLX3Ch/MjF5X03ov+OxxXGj25bsB+o=
+github.com/Sealights/libbuildpack-sealights v1.0.1 h1:CiZHibWfpA4XWD+TmJE3C0/quS0VYMulU3E753CvX/c=
+github.com/Sealights/libbuildpack-sealights v1.0.1/go.mod h1:ZX8o3uDgAa4zacLX3Ch/MjF5X03ov+OxxXGj25bsB+o=
 github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmxzcbUokwA=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=

--- a/vendor/github.com/Sealights/libbuildpack-sealights/launcher.go
+++ b/vendor/github.com/Sealights/libbuildpack-sealights/launcher.go
@@ -65,7 +65,10 @@ func (la *Launcher) buildCommandLine(command string) string {
 	options := la.Options
 
 	agent := filepath.Join(la.AgentDir, AgentName)
-	dotnetCli := filepath.Join(la.DotNetDir, "dotnet")
+	dotnetCli := "dotnet"
+	if la.DotNetDir != "" {
+		dotnetCli = filepath.Join(la.DotNetDir, "dotnet")
+	}
 
 	agentMode := DefaultAgentMode
 	if options.Mode != "" {
@@ -155,7 +158,7 @@ func (la *Launcher) buildCommandLine(command string) string {
 }
 
 func (la *Launcher) getTargetArgs(command string) (target string, args string) {
-	if strings.HasPrefix(command, "dotnet") {
+	if strings.HasPrefix(command, "dotnet") || la.DotNetDir == "" {
 		// use dotnet as target and remove it from command
 		target = "dotnet"
 		command = strings.TrimPrefix(command, "dotnet")

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -6,7 +6,7 @@ github.com/Dynatrace/libbuildpack-dynatrace
 # github.com/Masterminds/semver v1.5.0
 ## explicit
 github.com/Masterminds/semver
-# github.com/Sealights/libbuildpack-sealights v1.0.0
+# github.com/Sealights/libbuildpack-sealights v1.0.1
 ## explicit
 github.com/Sealights/libbuildpack-sealights
 # github.com/blang/semver v3.5.1+incompatible


### PR DESCRIPTION
In the newer version was fixed an issue with restricted dotnet SDK version number
Also was added a check that verifies is dotnet SDK 6.* already installed

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have added an integration test
