### PR TITLE
Bumped libbuildpack-sealights to v1.1.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/Dynatrace/libbuildpack-dynatrace v1.4.2
 	github.com/Masterminds/semver v1.5.0
-	github.com/Sealights/libbuildpack-sealights v1.0.1
+	github.com/Sealights/libbuildpack-sealights v1.1.0
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/cloudfoundry/libbuildpack v0.0.0-20220509111721-05ef1d6ca1f1
 	github.com/fsnotify/fsnotify v1.5.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF0
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
-github.com/Sealights/libbuildpack-sealights v1.0.1 h1:CiZHibWfpA4XWD+TmJE3C0/quS0VYMulU3E753CvX/c=
-github.com/Sealights/libbuildpack-sealights v1.0.1/go.mod h1:ZX8o3uDgAa4zacLX3Ch/MjF5X03ov+OxxXGj25bsB+o=
+github.com/Sealights/libbuildpack-sealights v1.1.0 h1:Wh9roxgIwqeN9GzgP9cDXZGfykQM5WeanaIg+MslsDQ=
+github.com/Sealights/libbuildpack-sealights v1.1.0/go.mod h1:ZX8o3uDgAa4zacLX3Ch/MjF5X03ov+OxxXGj25bsB+o=
 github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmxzcbUokwA=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=

--- a/vendor/github.com/Sealights/libbuildpack-sealights/README.md
+++ b/vendor/github.com/Sealights/libbuildpack-sealights/README.md
@@ -15,33 +15,16 @@ Cloud Foundry Buildpack integrations with Sealights
     Complete list of the prameters currently supported by the buildpack service is:
     ```
     {
-        "version": "string"                 //sealights version. default value - latest
-        "customAgentUrl": "string"          //sealights agent will be downloaded from this url if provided
-        "mode": "string"                    //execution stage. values: [config, scan, startExecution, testListener, endExecution]. default value - testListener
-        "token": "string"                   //sealights token
-        "tokenFile": "string"               //sealights token filename
-        "bsId": "string"                    //sealights session id
-        "bsIdFile": "string"                //sealights session id filename
-        "target": "string"                  //[testListener] target. default value is calculated based on app start command 
-        "targetArgs": "string"              //[testListener] target args. default value is calculated based on app start command 
-        "workingDir": "string"              //[testListener] target working directory. default value is calculated by cf
-        "profilerLogDir": "string"          //[testListener] profiler will write logs to this directory
-        "profilerLogLevel": "string"        //[testListener] profiler log level
-        "labId": "string"                   //lab id
-        "proxy": "string"
-        "proxyUsername": "string"
-        "proxyPassword": "string"
-        "ignoreCertificateErrors": "string" 
-        "tools": "string"
-        "tags": "string"
-        "notCli": "string"
-        "appName": "string"                 //[config] application name
-        "branchName": "string"              //[config] branch name
-        "buildName": "string"               //[config] build number
-        "includeNamespace": "string"        //[config] namespaces allow list
-        "workspacePath": "string"           //[scan] folder to scan. default value is app directory
-        "ignoreGeneratedCode": "string"     //[scan] ignore generated code
-        "testStage": "string"               //[startExecution] test stage name
+        "version"           // sealights version. default value - latest
+        "verb"              // execution stage. values: [config, scan, startExecution, testListener, endExecution]
+                            // in case if stage is not provided sealights service will not be called on container start
+        "customAgentUrl"    // sealights agent will be downloaded from this url if provided
+        "customCommand"     // allow to replace application start command
+        "proxy"             // proxy for the agent download client
+        "proxyUsername"     // proxy user
+        "proxyPassword"     // proxy password
+
+        + rest of the arguments that required for sealights service
     }
     ```
 

--- a/vendor/github.com/Sealights/libbuildpack-sealights/configuration.go
+++ b/vendor/github.com/Sealights/libbuildpack-sealights/configuration.go
@@ -13,33 +13,20 @@ type VcapServicesModel struct {
 }
 
 type SealightsOptions struct {
-	Version                 string
-	Mode                    string
-	Token                   string
-	TokenFile               string
-	BsId                    string
-	BsIdFile                string
-	Target                  string
-	WorkingDir              string
-	TargetArgs              string
-	ProfilerLogDir          string
-	ProfilerLogLevel        string
-	CustomAgentUrl          string
-	LabId                   string
-	Proxy                   string
-	ProxyUsername           string
-	ProxyPassword           string
-	IgnoreCertificateErrors string
-	Tools                   string
-	Tags                    string
-	NotCli                  string
-	AppName                 string
-	BranchName              string
-	BuildName               string
-	IncludeNamespace        string
-	WorkspacePath           string
-	IgnoreGeneratedCode     string
-	TestStage               string
+	Version          string
+	Verb             string
+	CustomAgentUrl   string
+	CustomCommand    string
+	LabId            string
+	Token            string
+	TokenFile        string
+	BsId             string
+	BsIdFile         string
+	ParseArgsFromCmd string
+	Proxy            string
+	ProxyUsername    string
+	ProxyPassword    string
+	SlArguments      map[string]string
 }
 
 type Configuration struct {
@@ -70,6 +57,13 @@ func (conf *Configuration) parseVcapServices() {
 		return
 	}
 
+	buildpackSpecificArguments := map[string]bool{
+		"version":        true,
+		"verb":           true,
+		"customAgentUrl": true,
+		"customCommand":  true,
+	}
+
 	for _, services := range vcapServices {
 		for _, service := range services {
 			if !strings.Contains(strings.ToLower(service.Name), "sealights") {
@@ -83,46 +77,41 @@ func (conf *Configuration) parseVcapServices() {
 				return ""
 			}
 
+			slArguments := map[string]string{}
+			for parameterName, parameterValue := range service.Credentials {
+				_, shouldBeSkipped := buildpackSpecificArguments[parameterName]
+				if shouldBeSkipped {
+					continue
+				}
+
+				slArguments[parameterName] = parameterValue.(string)
+			}
+
 			options := &SealightsOptions{
-				Version:                 queryString("version"),
-				Mode:                    queryString("mode"), // default value is 'testListener'
-				Token:                   queryString("token"),
-				TokenFile:               queryString("tokenFile"),
-				BsId:                    queryString("bsId"),
-				BsIdFile:                queryString("bsIdFile"),
-				Target:                  queryString("target"),
-				WorkingDir:              queryString("workingDir"),
-				TargetArgs:              queryString("targetArgs"),
-				ProfilerLogDir:          queryString("profilerLogDir"),
-				ProfilerLogLevel:        queryString("profilerLogLevel"),
-				CustomAgentUrl:          queryString("customAgentUrl"),
-				LabId:                   queryString("labId"),
-				Proxy:                   queryString("proxy"),
-				ProxyUsername:           queryString("proxyUsername"),
-				ProxyPassword:           queryString("proxyPassword"),
-				IgnoreCertificateErrors: queryString("ignoreCertificateErrors"),
-				Tools:                   queryString("tools"),
-				Tags:                    queryString("tags"),
-				NotCli:                  queryString("notCli"),
-				AppName:                 queryString("appName"),
-				BranchName:              queryString("branchName"),
-				BuildName:               queryString("buildName"),
-				IncludeNamespace:        queryString("includeNamespace"),
-				WorkspacePath:           queryString("workspacePath"),
-				IgnoreGeneratedCode:     queryString("ignoreGeneratedCode"),
-				TestStage:               queryString("testStage"),
+				Version:          queryString("version"),
+				Verb:             queryString("verb"),
+				CustomAgentUrl:   queryString("customAgentUrl"),
+				CustomCommand:    queryString("customCommand"),
+				Token:            queryString("token"),
+				TokenFile:        queryString("tokenFile"),
+				BsId:             queryString("buildSessionId"),
+				BsIdFile:         queryString("buildSessionIdFile"),
+				LabId:            queryString("labId"),
+				ParseArgsFromCmd: queryString("parseArgsFromCmd"),
+				Proxy:            queryString("proxy"),
+				ProxyUsername:    queryString("proxyUsername"),
+				ProxyPassword:    queryString("proxyPassword"),
+				SlArguments:      slArguments,
 			}
 
 			isTokenProvided := options.Token != "" || options.TokenFile != ""
 			if !isTokenProvided {
 				conf.Log.Warning("Sealights access token isn't provided")
-				return
 			}
 
 			isSessionIdProvided := options.BsId != "" || options.BsIdFile != ""
 			if !isSessionIdProvided {
 				conf.Log.Warning("Sealights build session id isn't provided")
-				return
 			}
 
 			conf.Value = options

--- a/vendor/github.com/Sealights/libbuildpack-sealights/hook.go
+++ b/vendor/github.com/Sealights/libbuildpack-sealights/hook.go
@@ -55,7 +55,7 @@ func (h *SealightsHook) AfterCompile(stager *libbuildpack.Stager) error {
 	}
 	h.Log.Info("Sealights. Dotnet is installed")
 
-	launcher := NewLauncher(h.Log, conf.Value, agentDir, dotnetDir)
+	launcher := NewLauncher(h.Log, conf.Value, agentDir, dotnetDir, stager.BuildDir())
 	launcher.ModifyStartParameters(stager)
 
 	h.Log.Info("Sealights. Service is set up")

--- a/vendor/github.com/Sealights/libbuildpack-sealights/launcher.go
+++ b/vendor/github.com/Sealights/libbuildpack-sealights/launcher.go
@@ -2,24 +2,31 @@ package sealights
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/cloudfoundry/libbuildpack"
 )
 
 const AgentName = "SL.DotNet.dll"
-const DefaultAgentMode = "testListener"
+const SealightsCli = "sealights"
+const DefaultAgentMode = "help"
+const ProfilerId = "01CA2C22-DC03-4FF5-8350-59E32A3536BA"
 
 type Launcher struct {
-	Log       *libbuildpack.Logger
-	Options   *SealightsOptions
-	AgentDir  string
-	DotNetDir string
+	Log                *libbuildpack.Logger
+	Options            *SealightsOptions
+	AgentDirAbsolute   string
+	AgentDirForRuntime string
+	DotNetDir          string
 }
 
-func NewLauncher(log *libbuildpack.Logger, options *SealightsOptions, agentInstallationDir string, dotnetInstallationDir string) *Launcher {
-	return &Launcher{Log: log, Options: options, AgentDir: agentInstallationDir, DotNetDir: dotnetInstallationDir}
+func NewLauncher(log *libbuildpack.Logger, options *SealightsOptions, agentInstallationDir string, dotnetInstallationDir string, buildDir string) *Launcher {
+	agentDirForRuntime := filepath.Join("${HOME}", agentInstallationDir)
+	agentDirAbsolute := filepath.Join(buildDir, agentInstallationDir)
+	return &Launcher{Log: log, Options: options, AgentDirForRuntime: agentDirForRuntime, AgentDirAbsolute: agentDirAbsolute, DotNetDir: dotnetInstallationDir}
 }
 
 func (la *Launcher) ModifyStartParameters(stager *libbuildpack.Stager) error {
@@ -29,9 +36,13 @@ func (la *Launcher) ModifyStartParameters(stager *libbuildpack.Stager) error {
 
 	startCommand := releaseInfo.GetStartCommand()
 	newStartCommand := la.updateStartCommand(startCommand)
-	err := releaseInfo.SetStartCommand(newStartCommand)
-	if err != nil {
-		return err
+
+	if la.Options.Verb != "" {
+		// update application launch command only if Verb is provided
+		err := releaseInfo.SetStartCommand(newStartCommand)
+		if err != nil {
+			return err
+		}
 	}
 
 	la.Log.Info(fmt.Sprintf("Sealights: Start command updated. From '%s' to '%s'", startCommand, newStartCommand))
@@ -40,9 +51,9 @@ func (la *Launcher) ModifyStartParameters(stager *libbuildpack.Stager) error {
 }
 
 func (la *Launcher) updateAgentPath(stager *libbuildpack.Stager) {
-	if strings.HasPrefix(la.AgentDir, stager.BuildDir()) {
-		clearPath := strings.TrimPrefix(la.AgentDir, stager.BuildDir())
-		la.AgentDir = filepath.Join(".", clearPath)
+	if strings.HasPrefix(la.AgentDirForRuntime, stager.BuildDir()) {
+		clearPath := strings.TrimPrefix(la.AgentDirForRuntime, stager.BuildDir())
+		la.AgentDirForRuntime = filepath.Join(".", clearPath)
 	}
 }
 
@@ -60,98 +71,61 @@ func (la *Launcher) updateStartCommand(originalCommand string) string {
 
 //dotnet SL.DotNet.dll testListener --logAppendFile true --logFilename /tmp/collector.log --tokenFile /tmp/sltoken.txt --buildSessionIdFile /tmp/buildsessionid.txt --target dotnet --workingDir /tmp/app --profilerLogDir /tmp/ --profilerLogLevel 7 --targetArgs \"test app.dll\"
 func (la *Launcher) buildCommandLine(command string) string {
+	if la.Options.CustomCommand != "" {
+		return la.Options.CustomCommand
+	}
 
 	var sb strings.Builder
 	options := la.Options
 
-	agent := filepath.Join(la.AgentDir, AgentName)
+	agent := filepath.Join(la.AgentDirForRuntime, AgentName)
 	dotnetCli := "dotnet"
 	if la.DotNetDir != "" {
 		dotnetCli = filepath.Join(la.DotNetDir, "dotnet")
 	}
 
 	agentMode := DefaultAgentMode
-	if options.Mode != "" {
-		agentMode = options.Mode
+	if options.Verb != "" {
+		agentMode = options.Verb
 	}
 
 	sb.WriteString(fmt.Sprintf("%s %s %s", dotnetCli, agent, agentMode))
 
-	if options.TokenFile != "" {
-		sb.WriteString(fmt.Sprintf(" --tokenfile %s", options.TokenFile))
-	} else {
-		sb.WriteString(fmt.Sprintf(" --token %s", options.Token))
+	for key, value := range la.Options.SlArguments {
+		la.Log.Info(fmt.Sprintf("Added: --%s %s", key, value))
+
+		sb.WriteString(fmt.Sprintf(" --%s %s", key, value))
 	}
 
-	if options.BsIdFile != "" {
-		sb.WriteString(fmt.Sprintf(" --buildSessionIdFile %s", options.BsIdFile))
-	} else {
-		sb.WriteString(fmt.Sprintf(" --buildSessionId %s", options.BsId))
+	if la.Options.ParseArgsFromCmd == "true" {
+		_, exists := la.Options.SlArguments["workingDir"]
+		if !exists {
+			sb.WriteString(" --workingDir ${PWD}")
+		}
+
+		parsedTarget, parsedArgs := la.getTargetArgs(command)
+		_, exists = la.Options.SlArguments["target"]
+		if !exists {
+			sb.WriteString(fmt.Sprintf(" --target %s", parsedTarget))
+		}
+
+		_, exists = la.Options.SlArguments["targetArgs"]
+		if !exists {
+			sb.WriteString(fmt.Sprintf(" --targetArgs \"%s\"", parsedArgs))
+		}
 	}
 
-	if options.ProfilerLogDir != "" {
-		sb.WriteString(fmt.Sprintf(" --profilerLogDir %s", options.ProfilerLogDir))
-	}
+	testListenerSessionKey, sessionKeyExists := la.Options.SlArguments["testListenerSessionKey"]
+	if sessionKeyExists {
+		exportEnvCmd, err := la.addProfilerConfiguration(la.AgentDirForRuntime, testListenerSessionKey)
+		if err != nil {
+			la.Log.Error("Sealights. Failed to parse arguments")
+			return command
+		}
 
-	if options.ProfilerLogLevel != "" {
-		sb.WriteString(fmt.Sprintf(" --profilerLogLevel %s", options.ProfilerLogLevel))
-	}
+		sb.WriteString(fmt.Sprintf(" && %s && %s", exportEnvCmd, command))
 
-	if options.Tags != "" {
-		sb.WriteString(fmt.Sprintf(" --tags %s", options.Tags))
-	}
-
-	if options.Tools != "" {
-		sb.WriteString(fmt.Sprintf(" --tools %s", options.Tools))
-	}
-
-	if options.IgnoreCertificateErrors == "true" {
-		sb.WriteString(" --ignoreCertificateErrors true")
-	}
-
-	if options.NotCli == "true" {
-		sb.WriteString(" --notCli true")
-	}
-
-	if options.AppName != "" {
-		sb.WriteString(fmt.Sprintf(" --appName %s", options.AppName))
-	}
-
-	if options.BranchName != "" {
-		sb.WriteString(fmt.Sprintf(" --branchName %s", options.BranchName))
-	}
-
-	if options.BuildName != "" {
-		sb.WriteString(fmt.Sprintf(" --buildName %s", options.BuildName))
-	}
-
-	if options.IncludeNamespace != "" {
-		sb.WriteString(fmt.Sprintf(" --includeNamespace %s", options.IncludeNamespace))
-	}
-
-	if options.WorkspacePath != "" {
-		sb.WriteString(fmt.Sprintf(" --workspacePath %s", options.WorkspacePath))
-	}
-
-	if options.IgnoreGeneratedCode != "" {
-		sb.WriteString(fmt.Sprintf(" --ignoreGeneratedCode %s", options.IgnoreGeneratedCode))
-	}
-
-	if options.TestStage != "" {
-		sb.WriteString(fmt.Sprintf(" --testStage %s", options.TestStage))
-	}
-
-	if options.Proxy != "" {
-		sb.WriteString(fmt.Sprintf(" --proxy %s", options.Proxy))
-		sb.WriteString(fmt.Sprintf(" --proxyUsername %s", options.ProxyUsername))
-		sb.WriteString(fmt.Sprintf(" --proxyPassword %s", options.ProxyPassword))
-	}
-
-	sb.WriteString(" --workingDir ${PWD}")
-
-	if agentMode == DefaultAgentMode {
-		target, args := la.getTargetArgs(command)
-		sb.WriteString(fmt.Sprintf(" --target %s --targetArgs \"%s\"", target, args))
+		la.addSealightsEntryPoint(dotnetCli, agent)
 	}
 
 	return sb.String()
@@ -172,17 +146,68 @@ func (la *Launcher) getTargetArgs(command string) (target string, args string) {
 	withoutArguments := parts[0]
 	args = fmt.Sprintf("test %s", withoutArguments)
 
-	if la.Options.Target != "" {
-		target = la.Options.Target
-	}
-
-	if la.Options.TargetArgs != "" {
-		args = la.Options.TargetArgs
-	}
-
 	if strings.HasPrefix(args, "--") {
 		args = fmt.Sprintf(" %s", args)
 	}
 
 	return
+}
+
+func (la *Launcher) addProfilerConfiguration(agentPath string, collectorId string) (string, error) {
+	agentEnvFileName := "sealights.envrc"
+	exportCommand := "export"
+	executeCommand := "source"
+
+	if runtime.GOOS == "windows" {
+		agentEnvFileName = "sealights.bat"
+		exportCommand = "set"
+		executeCommand = "call"
+	}
+
+	la.Log.Debug(fmt.Sprintf("Create file %s", agentEnvFileName))
+
+	agentEnvFile := filepath.Join(la.AgentDirAbsolute, agentEnvFileName)
+	homeBasedEnvFile := filepath.Join(la.AgentDirForRuntime, agentEnvFileName)
+	file, err := os.OpenFile(agentEnvFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		la.Log.Error(fmt.Sprint(err))
+		return "", err
+	}
+	defer file.Close()
+
+	agentProfilerLibx86 := filepath.Join(la.AgentDirForRuntime, "SL.DotNet.ProfilerLib_x86.dll")
+	agentProfilerLibx64 := filepath.Join(la.AgentDirForRuntime, "SL.DotNet.ProfilerLib_x64.dll")
+
+	fileContent := ""
+
+	fileContent += fmt.Sprintf("%s Cor_Profiler={%s}\n", exportCommand, ProfilerId)
+	fileContent += fmt.Sprintf("%s Cor_Enable_Profiling=1\n", exportCommand)
+	fileContent += fmt.Sprintf("%s Cor_Profiler_Path=%s\n", exportCommand, agentProfilerLibx64)
+	fileContent += fmt.Sprintf("%s COR_PROFILER_PATH_32=%s\n", exportCommand, agentProfilerLibx86)
+	fileContent += fmt.Sprintf("%s COR_PROFILER_PATH_64=%s\n", exportCommand, agentProfilerLibx64)
+	fileContent += fmt.Sprintf("%s SeaLights_CollectorId=%s\n", exportCommand, collectorId)
+
+	if _, err = file.WriteString(fileContent); err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%s %s && env", executeCommand, homeBasedEnvFile), nil
+}
+
+func (la *Launcher) addSealightsEntryPoint(dotnetCli string, agent string) error {
+	la.Log.Debug(fmt.Sprintf("Create file [%s] for cli", SealightsCli))
+
+	cliFileName := filepath.Join(la.AgentDirAbsolute, SealightsCli)
+	file, err := os.OpenFile(cliFileName, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0755)
+	if err != nil {
+		return err
+	}
+
+	defer file.Close()
+
+	runCmd := fmt.Sprintf(`exec %s %s "$$@"`, dotnetCli, agent)
+
+	file.WriteString(`#!/bin/sh` + "\n\n" + runCmd)
+
+	return nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -6,7 +6,7 @@ github.com/Dynatrace/libbuildpack-dynatrace
 # github.com/Masterminds/semver v1.5.0
 ## explicit
 github.com/Masterminds/semver
-# github.com/Sealights/libbuildpack-sealights v1.0.1
+# github.com/Sealights/libbuildpack-sealights v1.1.0
 ## explicit
 github.com/Sealights/libbuildpack-sealights
 # github.com/blang/semver v3.5.1+incompatible


### PR DESCRIPTION
Thanks for contributing to the buildpack. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Bumped libbuildpack-sealights to v1.1.0 that now support all parameters available for the sealights agent
Added the possibility to specify a proxy for agent downloading

* An explanation of the use cases your change solves
Usage of libbuildpack-dyntrace v1.1.0 enables additional parameters for sealights agent

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have added an integration test
