### PR TITLE
remove duplicate dynatrace fixture switch case

### DIFF
--- a/fixtures/util/dynatrace/main.go
+++ b/fixtures/util/dynatrace/main.go
@@ -32,7 +32,7 @@ func main() {
 				return
 			}
 
-		case "/manifest.json", "/dynatrace-env.sh", "/liboneagentproc.so":
+		case "/dynatrace-env.sh", "/liboneagentproc.so":
 			contents, err := os.ReadFile(strings.TrimPrefix(req.URL.Path, "/"))
 			if err != nil {
 				w.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
#691 introduced a duplicate switch case in the dynatrace fixture. This removes the duplicate to be more in line with the set up in the Go Buildpack equivalent fixture that this fixture is apparently based on.