### PR TITLE
Add ruxitagent to dynatrace switch case

### DIFF
--- a/fixtures/util/dynatrace/main.go
+++ b/fixtures/util/dynatrace/main.go
@@ -32,7 +32,7 @@ func main() {
 				return
 			}
 
-		case "/dynatrace-env.sh", "/liboneagentproc.so":
+		case "/dynatrace-env.sh", "/liboneagentproc.so", "/ruxitagentproc.conf":
 			contents, err := os.ReadFile(strings.TrimPrefix(req.URL.Path, "/"))
 			if err != nil {
 				w.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
Will hopefully resolve errors related to restaging the Dynatrace app.
Example: https://buildpacks.ci.cf-app.com/teams/main/pipelines/dotnet-core-buildpack/jobs/specs-edge-%E2%89%88-cflinuxfs3/builds/29