### PR TITLE
Bump github.com/Sealights/libbuildpack-sealights from 1.3.0 to 1.4.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/Dynatrace/libbuildpack-dynatrace v1.5.2
 	github.com/Masterminds/semver v1.5.0
-	github.com/Sealights/libbuildpack-sealights v1.3.0
+	github.com/Sealights/libbuildpack-sealights v1.4.0
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/cloudfoundry/libbuildpack v0.0.0-20231211162543-86d10e150195
 	github.com/go-ini/ini v1.67.0

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/Dynatrace/libbuildpack-dynatrace v1.5.2/go.mod h1:Uu9aa5UFAk1Ua+zZXnv
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
-github.com/Sealights/libbuildpack-sealights v1.3.0 h1:qwlkuOG/d5MjKagnJV+dQNcW4h+bOI/OE/2I87rFi8E=
-github.com/Sealights/libbuildpack-sealights v1.3.0/go.mod h1:ZwNZX2bhOVPKHnnWkYcq8GG4th05GkZRKr69mA0WtvU=
+github.com/Sealights/libbuildpack-sealights v1.4.0 h1:Gz5d7A1j6QadyTJ+N05ln9EKTb3x0PciFDjbQaxLlDo=
+github.com/Sealights/libbuildpack-sealights v1.4.0/go.mod h1:DO7SAzc01NCrI/D5bAs6vTOKX93/HzAq07rjgqCg2+c=
 github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmxzcbUokwA=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=

--- a/vendor/github.com/Sealights/libbuildpack-sealights/README.md
+++ b/vendor/github.com/Sealights/libbuildpack-sealights/README.md
@@ -15,15 +15,13 @@ Cloud Foundry Buildpack integrations with Sealights
     Complete list of the prameters currently supported by the buildpack service is:
     ```
     {
-        "version"               // sealights version. default value - latest
-        "verb"                  // execution stage. values: [config, scan, startExecution, testListener, endExecution]
-                                // in case if stage is not provided sealights service will not be called on container start
+        "version"               // sealights version. default value: 'latest'
+        "verb"                  // allow to specify command for the agent. default value: 'startBackgroundTestListener'
         "customAgentUrl"        // sealights agent will be downloaded from this url if provided
         "customCommand"         // allow to replace application start command
         "proxy"                 // proxy for the agent download client
         "proxyUsername"         // proxy user
         "proxyPassword"         // proxy password
-        "enableProfilerLogs"    // allow to enable logs in the profiler when listener is started in the background mode
 
         + rest of the parameters will be passed directly to the Sealights agent
     }
@@ -37,3 +35,9 @@ Cloud Foundry Buildpack integrations with Sealights
 
     cf restage [app name]
 
+## Logs
+
+You can enable Debug logs level by setting `BP_DEBUG` env variable:
+```
+cf set-env <your-app> BP_DEBUG True
+```

--- a/vendor/github.com/Sealights/libbuildpack-sealights/configuration.go
+++ b/vendor/github.com/Sealights/libbuildpack-sealights/configuration.go
@@ -14,15 +14,14 @@ type VcapServicesModel struct {
 }
 
 type SealightsOptions struct {
-	Version            string
-	Verb               string
-	CustomAgentUrl     string
-	CustomCommand      string
-	Proxy              string
-	ProxyUsername      string
-	ProxyPassword      string
-	EnableProfilerLogs string
-	SlArguments        map[string]string
+	Version        string
+	Verb           string
+	CustomAgentUrl string
+	CustomCommand  string
+	Proxy          string
+	ProxyUsername  string
+	ProxyPassword  string
+	SlArguments    map[string]string
 }
 
 type Configuration struct {
@@ -55,11 +54,10 @@ func (conf *Configuration) parseVcapServices() {
 	}
 
 	buildpackSpecificArguments := map[string]bool{
-		"version":            true,
-		"verb":               true,
-		"customAgentUrl":     true,
-		"customCommand":      true,
-		"enableProfilerLogs": true,
+		"version":        true,
+		"verb":           true,
+		"customAgentUrl": true,
+		"customCommand":  true,
 	}
 
 	for _, services := range vcapServices {
@@ -90,12 +88,10 @@ func (conf *Configuration) parseVcapServices() {
 				Verb:           queryString("verb"),
 				CustomAgentUrl: queryString("customAgentUrl"),
 				CustomCommand:  queryString("customCommand"),
-
-				Proxy:              queryString("proxy"),
-				ProxyUsername:      queryString("proxyUsername"),
-				ProxyPassword:      queryString("proxyPassword"),
-				EnableProfilerLogs: queryString("enableProfilerLogs"),
-				SlArguments:        slArguments,
+				Proxy:          queryString("proxy"),
+				ProxyUsername:  queryString("proxyUsername"),
+				ProxyPassword:  queryString("proxyPassword"),
+				SlArguments:    slArguments,
 			}
 
 			// write warning in case token or session is not provided
@@ -114,6 +110,15 @@ func (conf *Configuration) parseVcapServices() {
 			_, toolsProvided := options.SlArguments["tools"]
 			if !toolsProvided {
 				options.SlArguments["tools"] = conf.buildToolName()
+			}
+
+			if options.Verb == "" {
+				options.Verb = "startBackgroundTestListener"
+			}
+
+			_, collectorIdPorvided := options.SlArguments["testListenerSessionKey"]
+			if collectorIdPorvided {
+				conf.Log.Warning("Sealights. Option 'testListenerSessionKey' isn't supported in this environment")
 			}
 
 			conf.Value = options

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -7,7 +7,7 @@ github.com/Dynatrace/libbuildpack-dynatrace
 # github.com/Masterminds/semver v1.5.0
 ## explicit
 github.com/Masterminds/semver
-# github.com/Sealights/libbuildpack-sealights v1.3.0
+# github.com/Sealights/libbuildpack-sealights v1.4.0
 ## explicit; go 1.18
 github.com/Sealights/libbuildpack-sealights
 # github.com/blang/semver v3.5.1+incompatible


### PR DESCRIPTION
Sealights agent updated from 1.3.0 to 1.4.0
The new version of Sealight's agent supports different archive formats for "customAgentUrl" and does not require a "verb" parameter.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have added an integration test
