### PR TITLE
`BP_OPENSSL_ACTIVATE_LEGACY_PROVIDER`: load legacy ssl provider via env var

### DIFF
--- a/fixtures/source_apps/simple_legacy_openssl/README.md
+++ b/fixtures/source_apps/simple_legacy_openssl/README.md
@@ -1,4 +1,7 @@
-This app was generated with the .NET Core CLI v6:
-```
-dotnet new mvc -o source_6.0
-```
+This app is used to test the functionality to load the legacy openssl provider
+when using cflinuxfs4
+
+The app is tested with the addition of the `BP_OPENSSL_ACTIVATE_LEGACY_PROVIDER` environment
+variable set to `true`
+
+See ssl-related integration test in `src/dotnetcore/integration/default_test.go`

--- a/fixtures/source_apps/simple_legacy_openssl/buildpack.yml
+++ b/fixtures/source_apps/simple_legacy_openssl/buildpack.yml
@@ -1,3 +1,0 @@
-dotnet-core:
-  sdk: 6.0.x
-use_legacy_openssl: true

--- a/src/dotnetcore/integration/default_test.go
+++ b/src/dotnetcore/integration/default_test.go
@@ -213,11 +213,12 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 			})
 		})
 
-		context("with use_legacy_openssl specified in buildpack.yml", func() {
+		context("with BP_USE_LEGACY_OPENSSL set to `true`", func() {
 			it.Before(func() {
 				// this feature is not available on cflinuxfs3, because the stack already supports the legacy ssl provider
 				SkipOnCflinuxfs3(t)
 				app = cutlass.New(filepath.Join(settings.FixturesPath, "source_apps", "simple_legacy_openssl"))
+				app.SetEnv("BP_OPENSSL_ACTIVATE_LEGACY_PROVIDER", "true")
 			})
 
 			it("activates openssl legacy provider and builds/runs successfully", func() {


### PR DESCRIPTION
~~As a follow on from #905, allow users to also load the legacy openssl provider on cflinuxfs4 via a new environment variable, `BP_USE_LEGACY_OPENSSL`. This can be passed directly when running `cf push` or via `manifest.yml` file~~


add support for new `BP_OPENSSL_ACTIVATE_LEGACY_PROVIDER` environment variable
- Enabling the new environment variable will load and active the legacy openssl provider **on cflinuxfs4**
- Removes `use_legacy_openssl` buildpack.yml setting in favour of the environment variable