### PR TITLE
Bump github.com/Sealights/libbuildpack-sealights from 1.4.0 to 1.4.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/Dynatrace/libbuildpack-dynatrace v1.5.2
 	github.com/Masterminds/semver v1.5.0
-	github.com/Sealights/libbuildpack-sealights v1.4.0
+	github.com/Sealights/libbuildpack-sealights v1.4.1
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/cloudfoundry/libbuildpack v0.0.0-20231211162543-86d10e150195
 	github.com/go-ini/ini v1.67.0

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/Dynatrace/libbuildpack-dynatrace v1.5.2/go.mod h1:Uu9aa5UFAk1Ua+zZXnv
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
-github.com/Sealights/libbuildpack-sealights v1.4.0 h1:Gz5d7A1j6QadyTJ+N05ln9EKTb3x0PciFDjbQaxLlDo=
-github.com/Sealights/libbuildpack-sealights v1.4.0/go.mod h1:DO7SAzc01NCrI/D5bAs6vTOKX93/HzAq07rjgqCg2+c=
+github.com/Sealights/libbuildpack-sealights v1.4.1 h1:Oax/neU7gxIu0ISQgfMwyov316Cgz7K3o1zhR8WhMDA=
+github.com/Sealights/libbuildpack-sealights v1.4.1/go.mod h1:DO7SAzc01NCrI/D5bAs6vTOKX93/HzAq07rjgqCg2+c=
 github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmxzcbUokwA=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=

--- a/vendor/github.com/Sealights/libbuildpack-sealights/configuration.go
+++ b/vendor/github.com/Sealights/libbuildpack-sealights/configuration.go
@@ -112,6 +112,11 @@ func (conf *Configuration) parseVcapServices() {
 				options.SlArguments["tools"] = conf.buildToolName()
 			}
 
+			_, tagsProvided := options.SlArguments["tags"]
+			if !tagsProvided {
+				options.SlArguments["tags"] = conf.buildToolName()
+			}
+
 			if options.Verb == "" {
 				options.Verb = "startBackgroundTestListener"
 			}
@@ -128,12 +133,11 @@ func (conf *Configuration) parseVcapServices() {
 }
 
 func (conf *Configuration) buildToolName() string {
-	lang := conf.Stager.BuildpackLanguage()
 	ver, err := conf.Stager.BuildpackVersion()
 	if err != nil {
 		conf.Log.Warning("Failed to get buildpack version")
 		ver = "unknown"
 	}
 
-	return fmt.Sprintf("pcf-%s-%s", lang, ver)
+	return fmt.Sprintf("sl-pcf-%s", ver)
 }

--- a/vendor/github.com/Sealights/libbuildpack-sealights/launcher.go
+++ b/vendor/github.com/Sealights/libbuildpack-sealights/launcher.go
@@ -17,6 +17,8 @@ const WindowsAgentName = "SL.DotNet.exe"
 const LinuxProfilerId = "3B1DAA64-89D4-4999-ABF4-6A979B650B7D"
 const LinuxAgentName = "SL.DotNet"
 
+const DefaultPort = "31031"
+
 type Launcher struct {
 	Log                *libbuildpack.Logger
 	Options            *SealightsOptions
@@ -83,9 +85,10 @@ func (la *Launcher) buildCommandLine(command string) string {
 		return la.Options.CustomCommand
 	}
 
-	var sb strings.Builder
+	agentExecutable := la.agentFullPath()
 
-	sb.WriteString(fmt.Sprintf("%s %s", la.agentFillPath(), la.Options.Verb))
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%s %s", agentExecutable, la.Options.Verb))
 
 	for key, value := range la.Options.SlArguments {
 		sb.WriteString(fmt.Sprintf(" --%s %s", key, value))
@@ -152,6 +155,7 @@ func (la *Launcher) addProfilerConfiguration(agentPath string) (string, error) {
 	fileContent += fmt.Sprintf("%s CORECLR_PROFILER={%s}\n", exportCommand, profilerId)
 	fileContent += fmt.Sprintf("%s CORECLR_PROFILER_PATH_32=%s\n", exportCommand, agentProfilerLibx86)
 	fileContent += fmt.Sprintf("%s CORECLR_PROFILER_PATH_64=%s\n", exportCommand, agentProfilerLibx64)
+	fileContent += fmt.Sprintf("%s SL_AGENT_PORT=%s\n", exportCommand, DefaultPort)
 
 	testListenerSessionKey, sessionKeyExists := la.Options.SlArguments["testListenerSessionKey"]
 	if sessionKeyExists {
@@ -165,7 +169,7 @@ func (la *Launcher) addProfilerConfiguration(agentPath string) (string, error) {
 	return fmt.Sprintf("%s %s", executeCommand, homeBasedEnvFile), nil
 }
 
-func (la *Launcher) agentFillPath() string {
+func (la *Launcher) agentFullPath() string {
 	if runtime.GOOS == "windows" {
 		return filepath.Join(la.AgentDirForRuntime, WindowsAgentName)
 	} else {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -7,7 +7,7 @@ github.com/Dynatrace/libbuildpack-dynatrace
 # github.com/Masterminds/semver v1.5.0
 ## explicit
 github.com/Masterminds/semver
-# github.com/Sealights/libbuildpack-sealights v1.4.0
+# github.com/Sealights/libbuildpack-sealights v1.4.1
 ## explicit; go 1.18
 github.com/Sealights/libbuildpack-sealights
 # github.com/blang/semver v3.5.1+incompatible


### PR DESCRIPTION
Sealights agent updated from 1.4.0 to 1.4.1
The new version of Sealight's agent supports nuget package for "customAgentUrl" parameter.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have added an integration test
