### PR TITLE
tests: avoid using chrome-driver

### DIFF
--- a/src/dotnetcore/integration/node_test.go
+++ b/src/dotnetcore/integration/node_test.go
@@ -3,10 +3,8 @@ package integration_test
 import (
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/cloudfoundry/libbuildpack/cutlass"
-	"github.com/sclevine/agouti"
 	"github.com/sclevine/spec"
 
 	. "github.com/onsi/gomega"
@@ -14,44 +12,24 @@ import (
 
 func testNode(t *testing.T, context spec.G, it spec.S) {
 	var (
-		Expect     = NewWithT(t).Expect
-		Eventually = NewWithT(t).Eventually
-		app        *cutlass.App
-
-		agoutiDriver *agouti.WebDriver
-		page         *agouti.Page
+		Expect = NewWithT(t).Expect
+		app    *cutlass.App
 	)
 
 	it.Before(func() {
 		app = cutlass.New(filepath.Join(settings.FixturesPath, "node_apps", "angular_dotnet"))
 		app.Disk = "2G"
 		app.Memory = "2G"
-
-		var err error
-		agoutiDriver = agouti.ChromeDriver(agouti.ChromeOptions("args", []string{"--headless", "--disable-gpu", "--no-sandbox"}))
-		err = agoutiDriver.Start()
-		Expect(err).To(BeNil())
-
-		page, err = agoutiDriver.NewPage()
-		Expect(err).NotTo(HaveOccurred())
 	})
 
 	it.After(func() {
 		app = DestroyApp(t, app)
-		Expect(page.Destroy()).To(Succeed())
-
-		err := agoutiDriver.Stop()
-		Expect(err).To(BeNil())
 	})
 
 	context("deploying an angular app", func() {
 		it("displays a simple text homepage", func() {
 			PushAppAndConfirm(t, app)
-			url, err := app.GetUrl("/")
-			Expect(err).NotTo(HaveOccurred())
-
-			Expect(page.Navigate(url)).To(Succeed())
-			Eventually(page.HTML, 30*time.Second).Should(ContainSubstring("Hello, world!"))
+			Expect(app.GetBody("/")).To(ContainSubstring("<title>source_app</title>"))
 		})
 	})
 }


### PR DESCRIPTION
chrome-driver was removed from the CI image in
https://github.com/cloudfoundry/buildpacks-ci/pull/413.

Also, see how paketo tests the same app:
https://github.com/paketo-buildpacks/dotnet-core/blob/v0.48.2/integration/source_test.go#L94
