### PR TITLE
Bump github.com/Sealights/libbuildpack-sealights from 1.4.1 to 1.5.0 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/Dynatrace/libbuildpack-dynatrace v1.5.2
 	github.com/Masterminds/semver v1.5.0
-	github.com/Sealights/libbuildpack-sealights v1.4.1
+	github.com/Sealights/libbuildpack-sealights v1.5.0
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/cloudfoundry/libbuildpack v0.0.0-20231211162543-86d10e150195
 	github.com/go-ini/ini v1.67.0

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/Dynatrace/libbuildpack-dynatrace v1.5.2/go.mod h1:Uu9aa5UFAk1Ua+zZXnv
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
-github.com/Sealights/libbuildpack-sealights v1.4.1 h1:Oax/neU7gxIu0ISQgfMwyov316Cgz7K3o1zhR8WhMDA=
-github.com/Sealights/libbuildpack-sealights v1.4.1/go.mod h1:DO7SAzc01NCrI/D5bAs6vTOKX93/HzAq07rjgqCg2+c=
+github.com/Sealights/libbuildpack-sealights v1.5.0 h1:fsM+jS6UYkxuVO0iCAMi5JiXukkMEQ7RX6djfpQ1faA=
+github.com/Sealights/libbuildpack-sealights v1.5.0/go.mod h1:DO7SAzc01NCrI/D5bAs6vTOKX93/HzAq07rjgqCg2+c=
 github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmxzcbUokwA=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=

--- a/vendor/github.com/Sealights/libbuildpack-sealights/configuration.go
+++ b/vendor/github.com/Sealights/libbuildpack-sealights/configuration.go
@@ -21,7 +21,9 @@ type SealightsOptions struct {
 	Proxy          string
 	ProxyUsername  string
 	ProxyPassword  string
+	UsePic         bool
 	SlArguments    map[string]string
+	SlEnvironment  map[string]string
 }
 
 type Configuration struct {
@@ -58,6 +60,9 @@ func (conf *Configuration) parseVcapServices() {
 		"verb":           true,
 		"customAgentUrl": true,
 		"customCommand":  true,
+		"usePic":         true,
+		"cli":            true,
+		"env":            true,
 	}
 
 	for _, services := range vcapServices {
@@ -66,45 +71,59 @@ func (conf *Configuration) parseVcapServices() {
 				continue
 			}
 
-			queryString := func(key string) string {
-				if value, ok := service.Credentials[key].(string); ok {
-					return value
-				}
-				return ""
+			slEnvironment := getMap(service.Credentials, "env")
+			if slEnvironment == nil {
+				slEnvironment = make(map[string]string)
 			}
 
-			slArguments := map[string]string{}
-			for parameterName, parameterValue := range service.Credentials {
-				_, shouldBeSkipped := buildpackSpecificArguments[parameterName]
-				if shouldBeSkipped {
-					continue
-				}
+			slArguments := getMap(service.Credentials, "cli")
+			if slArguments == nil {
+				slArguments = make(map[string]string)
+			}
 
-				slArguments[parameterName] = parameterValue.(string)
+			// this validation required to make settings for version 1.5.0 back compatible with 1.4
+			// there is no property "cli" in the old version of the libpack - all fields for cli comes directly from settings
+			// so if env variables are set - all settings not from the new "cli" property will be used only by libpack itself
+			if len(slEnvironment) == 0 {
+				for parameterName, parameterValue := range service.Credentials {
+					_, shouldBeSkipped := buildpackSpecificArguments[parameterName]
+					if shouldBeSkipped {
+						continue
+					}
+
+					slArguments[parameterName] = parameterValue.(string)
+				}
+			} else {
+				conf.Log.Debug("Sealights. Option 'env' is provided - only options specified directly in the 'cli' field will be propagated to a command line")
 			}
 
 			options := &SealightsOptions{
-				Version:        queryString("version"),
-				Verb:           queryString("verb"),
-				CustomAgentUrl: queryString("customAgentUrl"),
-				CustomCommand:  queryString("customCommand"),
-				Proxy:          queryString("proxy"),
-				ProxyUsername:  queryString("proxyUsername"),
-				ProxyPassword:  queryString("proxyPassword"),
+				Version:        getValue[string](service.Credentials, "version"),
+				Verb:           getValue[string](service.Credentials, "verb"),
+				CustomAgentUrl: getValue[string](service.Credentials, "customAgentUrl"),
+				CustomCommand:  getValue[string](service.Credentials, "customCommand"),
+				Proxy:          getValue[string](service.Credentials, "proxy"),
+				ProxyUsername:  getValue[string](service.Credentials, "proxyUsername"),
+				ProxyPassword:  getValue[string](service.Credentials, "proxyPassword"),
+				UsePic:         getValue[bool](service.Credentials, "usePic"),
 				SlArguments:    slArguments,
+				SlEnvironment:  slEnvironment,
 			}
 
 			// write warning in case token or session is not provided
-			_, tokenProvided := options.SlArguments["token"]
-			_, tokenFileProvided := options.SlArguments["tokenFile"]
-			if !tokenProvided && !tokenFileProvided {
-				conf.Log.Warning("Sealights access token isn't provided")
+			tokenVariables := []string{"token", "tokenFile", "SL_TOKEN", "SL_TOKENFILE"}
+			isTokenProvided := conf.isAnyVariableProvided(tokenVariables, *options)
+			if !isTokenProvided {
+				conf.Log.Warning("The Sealights token has not been provided.")
 			}
 
-			_, sessionProvided := options.SlArguments["buildSessionId"]
-			_, sessionFileProvided := options.SlArguments["buildSessionIdFile"]
-			if !sessionProvided && !sessionFileProvided {
-				conf.Log.Warning("Sealights build session id isn't provided")
+			_, picEnabled := options.SlEnvironment["SL_PROFILER_INITIALIZECOLLECTOR"]
+			if picEnabled {
+				options.UsePic = true
+			}
+
+			if options.UsePic {
+				conf.Log.Info("Sealights. PIC mode enabled")
 			}
 
 			_, toolsProvided := options.SlArguments["tools"]
@@ -117,8 +136,9 @@ func (conf *Configuration) parseVcapServices() {
 				options.SlArguments["tags"] = conf.buildToolName()
 			}
 
-			if options.Verb == "" {
+			if options.Verb == "" && !options.UsePic {
 				options.Verb = "startBackgroundTestListener"
+				conf.Log.Debug("Sealights. Verb has not been set. Continue with 'startBackgroundTestListener'")
 			}
 
 			_, collectorIdPorvided := options.SlArguments["testListenerSessionKey"]
@@ -132,6 +152,22 @@ func (conf *Configuration) parseVcapServices() {
 	}
 }
 
+func (conf *Configuration) isAnyVariableProvided(variableName []string, options SealightsOptions) bool {
+	for _, key := range variableName {
+		_, variableProvided := options.SlArguments[key]
+		if variableProvided {
+			return true
+		}
+
+		_, variableProvided = options.SlEnvironment[key]
+		if variableProvided {
+			return true
+		}
+	}
+
+	return false
+}
+
 func (conf *Configuration) buildToolName() string {
 	ver, err := conf.Stager.BuildpackVersion()
 	if err != nil {
@@ -140,4 +176,24 @@ func (conf *Configuration) buildToolName() string {
 	}
 
 	return fmt.Sprintf("sl-pcf-%s", ver)
+}
+
+func getValue[T any](dict map[string]interface{}, key string) T {
+	var result T
+
+	if value, ok := dict[key].(T); ok {
+		return value
+	}
+
+	return result
+}
+
+func getMap(dict map[string]interface{}, key string) map[string]string {
+	var result = make(map[string]string)
+
+	for key, value := range getValue[map[string]interface{}](dict, key) {
+		result[key] = value.(string)
+	}
+
+	return result
 }

--- a/vendor/github.com/Sealights/libbuildpack-sealights/env_manager.go
+++ b/vendor/github.com/Sealights/libbuildpack-sealights/env_manager.go
@@ -1,0 +1,121 @@
+package sealights
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/cloudfoundry/libbuildpack"
+)
+
+const WindowsProfilerId = "{01CA2C22-DC03-4FF5-8350-59E32A3536BA}"
+const WingowsProfilerName32 = "SL.DotNet.ProfilerLib_x86.dll"
+const WingowsProfilerName64 = "SL.DotNet.ProfilerLib_x64.dll"
+
+const LinuxProfilerId = "{3B1DAA64-89D4-4999-ABF4-6A979B650B7D}"
+const LinuxProfilerName = "libSL.DotNet.ProfilerLib.Linux.so"
+
+const DefaultPort = "31031"
+
+type PlatformProfilerParams struct {
+	Name_32 string
+	Name_64 string
+	Id      string
+}
+
+type EnvManager struct {
+	Options *SealightsOptions
+	Log     *libbuildpack.Logger
+}
+
+func NewEnvManager(log *libbuildpack.Logger, options *SealightsOptions) *EnvManager {
+	envManager := EnvManager{Log: log, Options: options}
+
+	return &envManager
+}
+
+func (emng *EnvManager) GetVariables(runtimeDirectory string) map[string]string {
+	profilerInfo := emng.getProfilerInfo()
+
+	agentProfilerLibx86 := filepath.Join(runtimeDirectory, profilerInfo.Name_32)
+	agentProfilerLibx64 := filepath.Join(runtimeDirectory, profilerInfo.Name_64)
+
+	env_variables := map[string]string{}
+
+	env_variables["Cor_Profiler"] = profilerInfo.Id
+	env_variables["Cor_Enable_Profiling"] = "1"
+	env_variables["Cor_Profiler_Path"] = agentProfilerLibx64
+	env_variables["COR_PROFILER_PATH_32"] = agentProfilerLibx86
+	env_variables["COR_PROFILER_PATH_64"] = agentProfilerLibx64
+	env_variables["CORECLR_ENABLE_PROFILING"] = "1"
+	env_variables["CORECLR_PROFILER"] = profilerInfo.Id
+	env_variables["CORECLR_PROFILER_PATH_32"] = agentProfilerLibx86
+	env_variables["CORECLR_PROFILER_PATH_64"] = agentProfilerLibx64
+	env_variables["SL_AGENT_PORT"] = DefaultPort
+
+	testListenerSessionKey, sessionKeyExists := emng.Options.SlArguments["testListenerSessionKey"]
+	if sessionKeyExists {
+		env_variables["SL_CollectorId"] = testListenerSessionKey
+	}
+
+	if emng.Options.UsePic {
+		env_variables["SL_PROFILER_INITIALIZECOLLECTOR"] = "1"
+		env_variables["SL_PROFILER_BLOCKING_CONNECTION_STARTUP"] = "ASYNC"
+	}
+
+	// put to the dictionary provided variables and
+	// replace auto generated variables with provided
+	for key, value := range emng.Options.SlEnvironment {
+		env_variables[key] = value
+	}
+
+	return env_variables
+}
+
+func (emng *EnvManager) WriteIntoFile(filePath string, envVariables map[string]string) error {
+	exportCommand := "export"
+	if runtime.GOOS == "windows" {
+		exportCommand = "set"
+	}
+
+	file, err := os.OpenFile(filePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		emng.Log.Error(fmt.Sprint(err))
+		return err
+	}
+
+	defer file.Close()
+
+	fileContent := ""
+
+	for key, value := range envVariables {
+		fileContent += fmt.Sprintf("%s %s=%s\n", exportCommand, key, value)
+	}
+
+	if _, err = file.WriteString(fileContent); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (emng *EnvManager) getProfilerInfo() *PlatformProfilerParams {
+	if runtime.GOOS == "windows" {
+		profilerParams := PlatformProfilerParams{
+			Name_32: WingowsProfilerName32,
+			Name_64: WingowsProfilerName64,
+			Id:      WindowsProfilerId,
+		}
+
+		return &profilerParams
+	} else {
+		profilerParams := PlatformProfilerParams{
+			Name_32: LinuxProfilerName,
+			Name_64: LinuxProfilerName,
+			Id:      LinuxProfilerId,
+		}
+
+		return &profilerParams
+	}
+}

--- a/vendor/github.com/Sealights/libbuildpack-sealights/hook.go
+++ b/vendor/github.com/Sealights/libbuildpack-sealights/hook.go
@@ -31,7 +31,7 @@ func NewHook() libbuildpack.Hook {
 // AfterCompile downloads and installs the Sealights agent, and modify application start command
 func (h *SealightsHook) AfterCompile(stager *libbuildpack.Stager) error {
 
-	h.Log.Debug("Sealights. Check servicec status...")
+	h.Log.Debug("Sealights. Check service status...")
 
 	conf := NewConfiguration(h.Log, stager)
 	if !conf.UseSealights() {
@@ -49,7 +49,7 @@ func (h *SealightsHook) AfterCompile(stager *libbuildpack.Stager) error {
 	}
 	h.Log.Info("Sealights. Agent is installed (version: %s)", agentVersion)
 
-	launcher := NewLauncher(h.Log, conf.Value, agentDir, stager.BuildDir())
+	launcher := NewLauncher(h.Log, conf.Value, agentDir, stager)
 	launcher.ModifyStartParameters(stager)
 
 	h.Log.Info("Sealights. Service is set up")

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -7,7 +7,7 @@ github.com/Dynatrace/libbuildpack-dynatrace
 # github.com/Masterminds/semver v1.5.0
 ## explicit
 github.com/Masterminds/semver
-# github.com/Sealights/libbuildpack-sealights v1.4.1
+# github.com/Sealights/libbuildpack-sealights v1.5.0
 ## explicit; go 1.18
 github.com/Sealights/libbuildpack-sealights
 # github.com/blang/semver v3.5.1+incompatible
@@ -101,12 +101,6 @@ github.com/paketo-buildpacks/packit/pexec
 github.com/pkg/errors
 # github.com/sclevine/agouti v3.0.0+incompatible
 ## explicit
-github.com/sclevine/agouti
-github.com/sclevine/agouti/api
-github.com/sclevine/agouti/api/internal/bus
-github.com/sclevine/agouti/api/internal/service
-github.com/sclevine/agouti/internal/element
-github.com/sclevine/agouti/internal/target
 # github.com/sclevine/spec v1.4.0
 ## explicit; go 1.13
 github.com/sclevine/spec


### PR DESCRIPTION
Sealights agent updated from 1.4.1 to 1.5.0
The updated version allows to configure PIC mode for the agent

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have added an integration test
