### PR TITLE
Add cflinuxfs5 to stackToRuntimeRID in finalize

### DIFF
--- a/src/dotnetcore/finalize/finalize.go
+++ b/src/dotnetcore/finalize/finalize.go
@@ -17,6 +17,7 @@ import (
 var stackToRuntimeRID = map[string]string{
 	"cflinuxfs3": "linux-x64",
 	"cflinuxfs4": "linux-x64",
+	"cflinuxfs5": "linux-x64",
 }
 
 type Project interface {


### PR DESCRIPTION
cflinuxfs5 was missing from the stack→runtime RID map, causing finalize to fail with 'Unsupported stack: cflinuxfs5'. All cflinuxfs stacks use linux-x64 as the .NET runtime RID.