### PR TITLE
Skip EOL self-contained fixture tests on cflinuxfs5

### DIFF
--- a/src/dotnetcore/integration/default_test.go
+++ b/src/dotnetcore/integration/default_test.go
@@ -307,7 +307,7 @@ func testDefault(platform switchblade.Platform, fixtures string) func(*testing.T
 				Expect(err).NotTo(HaveOccurred())
 			})
 
-			it.Focus("displays a simple text homepage", func() {
+			it("displays a simple text homepage", func() {
 				// Fixture built for ubuntu.18.04-x64 with .NET 3.1; bundled OpenSSL 1.1 is incompatible with cflinuxfs5 (OpenSSL 3.0)
 				SkipOnCflinuxfs5(t)
 				deployment, logs, err := platform.Deploy.Execute(name, fixture)

--- a/src/dotnetcore/integration/default_test.go
+++ b/src/dotnetcore/integration/default_test.go
@@ -249,23 +249,22 @@ func testDefault(platform switchblade.Platform, fixtures string) func(*testing.T
 					Expect(err).NotTo(HaveOccurred())
 				})
 
-		it("activates openssl legacy provider and builds/runs successfully", func() {
-			deployment, logs, err := platform.Deploy.
-				WithEnv(map[string]string{
-					"BP_OPENSSL_ACTIVATE_LEGACY_PROVIDER": "true",
-				}).
-				Execute(name, fixture)
-			Expect(err).NotTo(HaveOccurred())
+				it("activates openssl legacy provider and builds/runs successfully", func() {
+					deployment, logs, err := platform.Deploy.
+						WithEnv(map[string]string{
+							"BP_OPENSSL_ACTIVATE_LEGACY_PROVIDER": "true",
+						}).
+						Execute(name, fixture)
+					Expect(err).NotTo(HaveOccurred())
 
-			// Check that the legacy SSL provider was loaded during build
-			Expect(logs).To(ContainSubstring("Loading legacy SSL provider"))
-			Eventually(func() string {
-					logs, _ := deployment.RuntimeLogs()
-					return logs 
-					}, "10s", "1s").Should(Or(ContainSubstring("name: OpenSSL Legacy Provider"),
-				))
+					// Check that the legacy SSL provider was loaded during build
+					Expect(logs).To(ContainSubstring("Loading legacy SSL provider"))
+					Eventually(func() string {
+						logs, _ := deployment.RuntimeLogs()
+						return logs
+					}, "10s", "1s").Should(Or(ContainSubstring("name: OpenSSL Legacy Provider")))
+				})
 			})
-		})
 		})
 
 		context("deploying a framework-dependent app", func() {
@@ -308,7 +307,9 @@ func testDefault(platform switchblade.Platform, fixtures string) func(*testing.T
 				Expect(err).NotTo(HaveOccurred())
 			})
 
-			it("displays a simple text homepage", func() {
+			it.Focus("displays a simple text homepage", func() {
+				// Fixture built for ubuntu.18.04-x64 with .NET 3.1; bundled OpenSSL 1.1 is incompatible with cflinuxfs5 (OpenSSL 3.0)
+				SkipOnCflinuxfs5(t)
 				deployment, logs, err := platform.Deploy.Execute(name, fixture)
 				Expect(err).NotTo(HaveOccurred())
 

--- a/src/dotnetcore/integration/init_test.go
+++ b/src/dotnetcore/integration/init_test.go
@@ -174,3 +174,9 @@ func SkipOnCflinuxfs3(t *testing.T) {
 		t.Skip("Skipping test not relevant for stack cflinuxfs3")
 	}
 }
+
+func SkipOnCflinuxfs5(t *testing.T) {
+	if settings.Stack == "cflinuxfs5" {
+		t.Skip("Skipping test not relevant for stack cflinuxfs5")
+	}
+}

--- a/src/dotnetcore/integration/multiple_projects_test.go
+++ b/src/dotnetcore/integration/multiple_projects_test.go
@@ -45,7 +45,7 @@ func testMultipleProjects(platform switchblade.Platform, fixtures string) func(*
 		})
 
 		context("Deploying a self-contained solution with multiple projects", func() {
-			it.Focus("can run the app", func() {
+			it("can run the app", func() {
 				// Fixture built for .NET 2.2 (EOL); bundled OpenSSL 1.1 is incompatible with cflinuxfs5 (OpenSSL 3.0)
 				SkipOnCflinuxfs5(t)
 				deployment, _, err := platform.Deploy.

--- a/src/dotnetcore/integration/multiple_projects_test.go
+++ b/src/dotnetcore/integration/multiple_projects_test.go
@@ -38,15 +38,16 @@ func testMultipleProjects(platform switchblade.Platform, fixtures string) func(*
 			Eventually(deployment).Should(Serve(ContainSubstring("Hello, I'm a string!")))
 
 			Eventually(func() string {
-					logs, _ := deployment.RuntimeLogs()
-					return logs 
-					}, "10s", "1s").Should(Or(ContainSubstring("Hello from a secondary project!"),
-			))
+				logs, _ := deployment.RuntimeLogs()
+				return logs
+			}, "10s", "1s").Should(Or(ContainSubstring("Hello from a secondary project!")))
 
 		})
 
 		context("Deploying a self-contained solution with multiple projects", func() {
-			it("can run the app", func() {
+			it.Focus("can run the app", func() {
+				// Fixture built for .NET 2.2 (EOL); bundled OpenSSL 1.1 is incompatible with cflinuxfs5 (OpenSSL 3.0)
+				SkipOnCflinuxfs5(t)
 				deployment, _, err := platform.Deploy.
 					Execute(name, filepath.Join(fixtures, "self_contained_apps", "self_contained_solution_2.2"))
 				Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
## Summary

Skips two integration tests on cflinuxfs5 that use pre-built self-contained app fixtures compiled for `ubuntu.18.04-x64`:

| Test | Fixture | .NET version |
|---|---|---|
| `displays a simple text homepage` | `self_contained_apps/msbuild` | 3.1.17 |
| `can run the app` | `self_contained_apps/self_contained_solution_2.2` | 2.2 |

### Root cause

These fixtures were published with `--runtime ubuntu.18.04-x64` and bundle OpenSSL 1.1 native libraries. cflinuxfs5 (Ubuntu 24.04) ships only OpenSSL 3.0 — `libssl.so.1.1` does not exist, so the self-contained executable crashes immediately at startup, causing the test to time out with `connection refused` / `connection reset by peer`.

Both .NET versions are EOL and will not be rebuilt for cflinuxfs5.

### Changes

- Added `SkipOnCflinuxfs5(t)` helper to `init_test.go`, mirroring the   existing `SkipOnCflinuxfs3` pattern.
- Applied the skip to the two affected `it.Focus` tests.

### Testing

Verified locally with `CF_STACK=cflinuxfs5 ./scripts/integration.sh --platform docker`.