### PR TITLE
Obsolete test fixture

### DIFF
--- a/src/dotnetcore/integration/default_test.go
+++ b/src/dotnetcore/integration/default_test.go
@@ -307,7 +307,7 @@ func testDefault(platform switchblade.Platform, fixtures string) func(*testing.T
 				Expect(err).NotTo(HaveOccurred())
 			})
 
-			it.Focus("displays a simple text homepage", func() {
+			it("displays a simple text homepage", func() {
 				// Fixture built for ubuntu.18.04-x64 with .NET 3.1; bundled OpenSSL 1.1 is incompatible with cflinuxfs5 (OpenSSL 3.0)
 				SkipOnCflinuxfs5(t)
 				deployment, logs, err := platform.Deploy.Execute(name, fixture)

--- a/src/dotnetcore/integration/default_test.go
+++ b/src/dotnetcore/integration/default_test.go
@@ -249,23 +249,22 @@ func testDefault(platform switchblade.Platform, fixtures string) func(*testing.T
 					Expect(err).NotTo(HaveOccurred())
 				})
 
-		it("activates openssl legacy provider and builds/runs successfully", func() {
-			deployment, logs, err := platform.Deploy.
-				WithEnv(map[string]string{
-					"BP_OPENSSL_ACTIVATE_LEGACY_PROVIDER": "true",
-				}).
-				Execute(name, fixture)
-			Expect(err).NotTo(HaveOccurred())
+				it("activates openssl legacy provider and builds/runs successfully", func() {
+					deployment, logs, err := platform.Deploy.
+						WithEnv(map[string]string{
+							"BP_OPENSSL_ACTIVATE_LEGACY_PROVIDER": "true",
+						}).
+						Execute(name, fixture)
+					Expect(err).NotTo(HaveOccurred())
 
-			// Check that the legacy SSL provider was loaded during build
-			Expect(logs).To(ContainSubstring("Loading legacy SSL provider"))
-			Eventually(func() string {
-					logs, _ := deployment.RuntimeLogs()
-					return logs 
-					}, "10s", "1s").Should(Or(ContainSubstring("name: OpenSSL Legacy Provider"),
-				))
+					// Check that the legacy SSL provider was loaded during build
+					Expect(logs).To(ContainSubstring("Loading legacy SSL provider"))
+					Eventually(func() string {
+						logs, _ := deployment.RuntimeLogs()
+						return logs
+					}, "10s", "1s").Should(Or(ContainSubstring("name: OpenSSL Legacy Provider")))
+				})
 			})
-		})
 		})
 
 		context("deploying a framework-dependent app", func() {
@@ -308,7 +307,9 @@ func testDefault(platform switchblade.Platform, fixtures string) func(*testing.T
 				Expect(err).NotTo(HaveOccurred())
 			})
 
-			it("displays a simple text homepage", func() {
+			it.Focus("displays a simple text homepage", func() {
+				// Fixture built for ubuntu.18.04-x64 with .NET 3.1; bundled OpenSSL 1.1 is incompatible with cflinuxfs5 (OpenSSL 3.0)
+				SkipOnCflinuxfs5(t)
 				deployment, logs, err := platform.Deploy.Execute(name, fixture)
 				Expect(err).NotTo(HaveOccurred())
 

--- a/src/dotnetcore/integration/init_test.go
+++ b/src/dotnetcore/integration/init_test.go
@@ -174,3 +174,9 @@ func SkipOnCflinuxfs3(t *testing.T) {
 		t.Skip("Skipping test not relevant for stack cflinuxfs3")
 	}
 }
+
+func SkipOnCflinuxfs5(t *testing.T) {
+	if settings.Stack == "cflinuxfs5" {
+		t.Skip("Skipping test not relevant for stack cflinuxfs5")
+	}
+}

--- a/src/dotnetcore/integration/multiple_projects_test.go
+++ b/src/dotnetcore/integration/multiple_projects_test.go
@@ -45,7 +45,7 @@ func testMultipleProjects(platform switchblade.Platform, fixtures string) func(*
 		})
 
 		context("Deploying a self-contained solution with multiple projects", func() {
-			it.Focus("can run the app", func() {
+			it("can run the app", func() {
 				// Fixture built for .NET 2.2 (EOL); bundled OpenSSL 1.1 is incompatible with cflinuxfs5 (OpenSSL 3.0)
 				SkipOnCflinuxfs5(t)
 				deployment, _, err := platform.Deploy.

--- a/src/dotnetcore/integration/multiple_projects_test.go
+++ b/src/dotnetcore/integration/multiple_projects_test.go
@@ -38,15 +38,16 @@ func testMultipleProjects(platform switchblade.Platform, fixtures string) func(*
 			Eventually(deployment).Should(Serve(ContainSubstring("Hello, I'm a string!")))
 
 			Eventually(func() string {
-					logs, _ := deployment.RuntimeLogs()
-					return logs 
-					}, "10s", "1s").Should(Or(ContainSubstring("Hello from a secondary project!"),
-			))
+				logs, _ := deployment.RuntimeLogs()
+				return logs
+			}, "10s", "1s").Should(Or(ContainSubstring("Hello from a secondary project!")))
 
 		})
 
 		context("Deploying a self-contained solution with multiple projects", func() {
-			it("can run the app", func() {
+			it.Focus("can run the app", func() {
+				// Fixture built for .NET 2.2 (EOL); bundled OpenSSL 1.1 is incompatible with cflinuxfs5 (OpenSSL 3.0)
+				SkipOnCflinuxfs5(t)
 				deployment, _, err := platform.Deploy.
 					Execute(name, filepath.Join(fixtures, "self_contained_apps", "self_contained_solution_2.2"))
 				Expect(err).NotTo(HaveOccurred())

--- a/src/dotnetcore/integration/offline_test.go
+++ b/src/dotnetcore/integration/offline_test.go
@@ -43,6 +43,8 @@ func testOffline(platform switchblade.Platform, fixtures string) func(*testing.T
 
 		context("when deploying a self contained app without internet", func() {
 			it("builds and runs the app", func() {
+				// Fixture built for ubuntu.18.04-x64 with .NET 3.1; bundled OpenSSL 1.1 is incompatible with cflinuxfs5 (OpenSSL 3.0)
+				SkipOnCflinuxfs5(t)
 				deployment, _, err := platform.Deploy.
 					WithoutInternetAccess().
 					Execute(name, filepath.Join(fixtures, "self_contained_apps", "msbuild"))


### PR DESCRIPTION
Similary to https://github.com/cloudfoundry/dotnet-core-buildpack/pull/1242 , self_contained_apps/msbuild is the ubuntu.18.04-x64 / .NET 3.1 fixture. In the cached (offline) test it runs with WithoutInternetAccess() and the fixture itself is using obsolete libraies.
