### PR TITLE
Fix cflinuxfs5 integration test cleanup failures

### DIFF
--- a/src/dotnetcore/integration/default_test.go
+++ b/src/dotnetcore/integration/default_test.go
@@ -301,6 +301,15 @@ func testDefault(platform switchblade.Platform, fixtures string) func(*testing.T
 		})
 
 		context("deploying a self contained msbuild app with RuntimeIdentfier", func() {
+			// Skip entire context for cflinuxfs5: Fixture built for ubuntu.18.04-x64 with .NET 3.1;
+			// bundled OpenSSL 1.1 is incompatible with cflinuxfs5 (OpenSSL 3.0)
+			if settings.Stack == "cflinuxfs5" {
+				it("displays a simple text homepage", func() {
+					t.Skip("Skipping test not relevant for stack cflinuxfs5")
+				})
+				return
+			}
+
 			it.Before(func() {
 				var err error
 				fixture, err = switchblade.Source(filepath.Join(fixtures, "self_contained_apps", "msbuild"))
@@ -308,8 +317,6 @@ func testDefault(platform switchblade.Platform, fixtures string) func(*testing.T
 			})
 
 			it("displays a simple text homepage", func() {
-				// Fixture built for ubuntu.18.04-x64 with .NET 3.1; bundled OpenSSL 1.1 is incompatible with cflinuxfs5 (OpenSSL 3.0)
-				SkipOnCflinuxfs5(t)
 				deployment, logs, err := platform.Deploy.Execute(name, fixture)
 				Expect(err).NotTo(HaveOccurred())
 

--- a/src/dotnetcore/integration/default_test.go
+++ b/src/dotnetcore/integration/default_test.go
@@ -304,9 +304,6 @@ func testDefault(platform switchblade.Platform, fixtures string) func(*testing.T
 			// Skip entire context for cflinuxfs5: Fixture built for ubuntu.18.04-x64 with .NET 3.1;
 			// bundled OpenSSL 1.1 is incompatible with cflinuxfs5 (OpenSSL 3.0)
 			if settings.Stack == "cflinuxfs5" {
-				it("displays a simple text homepage", func() {
-					t.Skip("Skipping test not relevant for stack cflinuxfs5")
-				})
 				return
 			}
 

--- a/src/dotnetcore/integration/multiple_projects_test.go
+++ b/src/dotnetcore/integration/multiple_projects_test.go
@@ -45,9 +45,16 @@ func testMultipleProjects(platform switchblade.Platform, fixtures string) func(*
 		})
 
 		context("Deploying a self-contained solution with multiple projects", func() {
+			// Skip entire context for cflinuxfs5: Fixture built for .NET 2.2 (EOL);
+			// bundled OpenSSL 1.1 is incompatible with cflinuxfs5 (OpenSSL 3.0)
+			if settings.Stack == "cflinuxfs5" {
+				it("can run the app", func() {
+					t.Skip("Skipping test not relevant for stack cflinuxfs5")
+				})
+				return
+			}
+
 			it("can run the app", func() {
-				// Fixture built for .NET 2.2 (EOL); bundled OpenSSL 1.1 is incompatible with cflinuxfs5 (OpenSSL 3.0)
-				SkipOnCflinuxfs5(t)
 				deployment, _, err := platform.Deploy.
 					Execute(name, filepath.Join(fixtures, "self_contained_apps", "self_contained_solution_2.2"))
 				Expect(err).NotTo(HaveOccurred())

--- a/src/dotnetcore/integration/multiple_projects_test.go
+++ b/src/dotnetcore/integration/multiple_projects_test.go
@@ -48,9 +48,6 @@ func testMultipleProjects(platform switchblade.Platform, fixtures string) func(*
 			// Skip entire context for cflinuxfs5: Fixture built for .NET 2.2 (EOL);
 			// bundled OpenSSL 1.1 is incompatible with cflinuxfs5 (OpenSSL 3.0)
 			if settings.Stack == "cflinuxfs5" {
-				it("can run the app", func() {
-					t.Skip("Skipping test not relevant for stack cflinuxfs5")
-				})
 				return
 			}
 

--- a/src/dotnetcore/integration/offline_test.go
+++ b/src/dotnetcore/integration/offline_test.go
@@ -42,9 +42,16 @@ func testOffline(platform switchblade.Platform, fixtures string) func(*testing.T
 		})
 
 		context("when deploying a self contained app without internet", func() {
+			// Skip entire context for cflinuxfs5: Fixture built for ubuntu.18.04-x64 with .NET 3.1;
+			// bundled OpenSSL 1.1 is incompatible with cflinuxfs5 (OpenSSL 3.0)
+			if settings.Stack == "cflinuxfs5" {
+				it("builds and runs the app", func() {
+					t.Skip("Skipping test not relevant for stack cflinuxfs5")
+				})
+				return
+			}
+
 			it("builds and runs the app", func() {
-				// Fixture built for ubuntu.18.04-x64 with .NET 3.1; bundled OpenSSL 1.1 is incompatible with cflinuxfs5 (OpenSSL 3.0)
-				SkipOnCflinuxfs5(t)
 				deployment, _, err := platform.Deploy.
 					WithoutInternetAccess().
 					Execute(name, filepath.Join(fixtures, "self_contained_apps", "msbuild"))

--- a/src/dotnetcore/integration/offline_test.go
+++ b/src/dotnetcore/integration/offline_test.go
@@ -45,9 +45,6 @@ func testOffline(platform switchblade.Platform, fixtures string) func(*testing.T
 			// Skip entire context for cflinuxfs5: Fixture built for ubuntu.18.04-x64 with .NET 3.1;
 			// bundled OpenSSL 1.1 is incompatible with cflinuxfs5 (OpenSSL 3.0)
 			if settings.Stack == "cflinuxfs5" {
-				it("builds and runs the app", func() {
-					t.Skip("Skipping test not relevant for stack cflinuxfs5")
-				})
 				return
 			}
 


### PR DESCRIPTION
## Summary

Fixes cleanup failures in integration tests when running on cflinuxfs5 stack by moving stack compatibility checks to the context level instead of inside test functions.

## Problem

Build #1 of the create-cf-infrastructure-and-execute-integration-test-for-dotnet-core job was failing with these errors:

```
failed to delete-org: exit status 1
Output: No API endpoint set. Use 'cf login' or 'cf api' to target an endpoint.
```

**Failing Tests:**
- TestIntegration/integration/Default/deploying_a_self_contained_msbuild_app_with_RuntimeIdentfier/displays_a_simple_text_homepage
- TestIntegration/integration/MultipleProjects/Deploying_a_self-contained_solution_with_multiple_projects/can_run_the_app

### Root Cause

The test structure was:

1. it.Before() - Sets up app name
2. Test function starts → calls SkipOnCflinuxfs5(t) → test exits
3. platform.Deploy.Execute() never runs → CF workspace never initialized  
4. it.After() still runs (cleanup always runs) → tries to delete org
5. CF CLI fails because no API endpoint was ever set

## Solution

Move the stack compatibility check to the context level (before it.Before()), so when a test isn't relevant for cflinuxfs5:
- The entire context is skipped
- Setup (it.Before) doesn't run
- Cleanup (it.After) doesn't run
- No resources are created, so nothing needs cleaning up

### Why These Tests Are cflinuxfs4-Only

All three affected tests use self-contained .NET app fixtures:
- Built for ubuntu.18.04-x64
- Bundle .NET Core 2.2 or 3.1 runtimes
- Include OpenSSL 1.1 (bundled with those runtime versions)
- Incompatible with cflinuxfs5 which uses OpenSSL 3.0

## Changes

- default_test.go: Skip "self contained msbuild app" test at context level
- multiple_projects_test.go: Skip "self-contained solution 2.2" test at context level
- offline_test.go: Skip "self contained app without internet" test at context level

## Testing

- [x] Code compiles successfully (go test -c)
- [ ] Waiting for CI to verify fix in pipeline

## Related

Build that exposed the issue: https://concourse.app-runtime-interfaces.ci.cloudfoundry.org/teams/buildpacks-team/pipelines/dotnet-core-buildpack/jobs/create-cf-infrastructure-and-execute-integration-test-for-dotnet-core/builds/1