### PR TITLE
Increase staging timeout for angular integration test

### DIFF
--- a/src/dotnetcore/integration/node_test.go
+++ b/src/dotnetcore/integration/node_test.go
@@ -1,6 +1,7 @@
 package integration_test
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -32,6 +33,10 @@ func testNode(platform switchblade.Platform, fixtures string) func(*testing.T, s
 
 		context("deploying an angular app", func() {
 			it("displays a simple text homepage", func() {
+				prevTimeout := os.Getenv("CF_STAGING_TIMEOUT")
+				os.Setenv("CF_STAGING_TIMEOUT", "30")
+				defer os.Setenv("CF_STAGING_TIMEOUT", prevTimeout)
+
 				deployment, _, err := platform.Deploy.
 					Execute(name, filepath.Join(fixtures, "node_apps", "angular_dotnet"))
 				Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
## Summary

- Set `CF_STAGING_TIMEOUT=30` (minutes) for the angular app integration test to prevent staging timeouts

## Problem

The `angular_dotnet` fixture has heavy npm dependencies (~939 packages). During staging, `npm install` + `ng build --prod` can exceed the default 15-minute CF staging timeout, causing the "deploying an angular app" test to fail intermittently.

## Fix

Set the `CF_STAGING_TIMEOUT` environment variable to 30 minutes, scoped only to the angular test. The previous value is restored after the test completes.