### PR TITLE
Export DOTNET_GCHeapHardLimit from MEMORY_LIMIT to fix cgroup v2 memory handling

### DIFF
--- a/fixtures/source_apps/simple/Program.cs
+++ b/fixtures/source_apps/simple/Program.cs
@@ -24,4 +24,6 @@ app.MapControllerRoute(
     name: "default",
     pattern: "{controller=Home}/{action=Index}/{id?}");
 
+app.MapGet("/env/dotnet-gc-heap-hard-limit", () => Environment.GetEnvironmentVariable("DOTNET_GCHeapHardLimit") ?? "");
+
 app.Run();

--- a/fixtures/source_apps/simple/Program.cs
+++ b/fixtures/source_apps/simple/Program.cs
@@ -24,6 +24,10 @@ app.MapControllerRoute(
     name: "default",
     pattern: "{controller=Home}/{action=Index}/{id?}");
 
-app.MapGet("/env/dotnet-gc-heap-hard-limit", () => Environment.GetEnvironmentVariable("DOTNET_GCHeapHardLimit") ?? "");
+// Reports the GC's actual resolved GCHeapHardLimit configuration (via GC.GetConfigurationVariables(),
+// available since .NET 7) rather than the raw DOTNET_GCHeapHardLimit environment variable, proving
+// the CLR itself parsed and applied the value rather than merely being present in the shell environment.
+// The "GCHeapHardLimit" key is always present in the dictionary (0 when unconfigured), so no fallback is needed.
+app.MapGet("/env/dotnet-gc-heap-hard-limit", () => $"0x{(long)GC.GetConfigurationVariables()["GCHeapHardLimit"]:x}");
 
 app.Run();

--- a/src/dotnetcore/finalize/finalize.go
+++ b/src/dotnetcore/finalize/finalize.go
@@ -177,6 +177,43 @@ func (f *Finalizer) WriteProfileD() error {
 	scriptContents := fmt.Sprintf(`
 export ASPNETCORE_URLS="${ASPNETCORE_URLS:-http://0.0.0.0:${PORT}}"
 export DOTNET_ROOT=%s
+
+if [[ "${MEMORY_LIMIT:-}" =~ ^([0-9]+)m$ ]]; then
+  __dgchl_mb=$((10#${BASH_REMATCH[1]}))
+
+  if [ "$__dgchl_mb" -gt 0 ]; then
+    __dgchl_limit_bytes=$(( __dgchl_mb * 1024 * 1024 ))
+
+    if [[ -n "${DOTNET_GCHeapHardLimit:-}" ]]; then
+      __dgchl_hex="${DOTNET_GCHeapHardLimit#0x}"
+      __dgchl_hex="${__dgchl_hex#0X}"
+    fi
+
+    if [[ -n "${__dgchl_hex:-}" ]] && [[ "$__dgchl_hex" =~ ^[0-9a-fA-F]+$ ]]; then
+      __dgchl_proposed_bytes=$(( 16#${__dgchl_hex} ))
+    else
+      __dgchl_percent_raw="${DOTNET_GCHeapHardLimitPercent:-75}"
+      if [[ "$__dgchl_percent_raw" =~ ^[0-9]{1,3}$ ]]; then
+        __dgchl_percent=$((10#$__dgchl_percent_raw))
+        if [ "$__dgchl_percent" -lt 1 ] || [ "$__dgchl_percent" -gt 100 ]; then
+          __dgchl_percent=75
+        fi
+      else
+        __dgchl_percent=75
+      fi
+      __dgchl_proposed_bytes=$(( __dgchl_limit_bytes * __dgchl_percent / 100 ))
+    fi
+
+    if [ "$__dgchl_proposed_bytes" -gt "$__dgchl_limit_bytes" ]; then
+      echo "WARNING: DOTNET_GCHeapHardLimit (${__dgchl_proposed_bytes} bytes) exceeds MEMORY_LIMIT (${__dgchl_limit_bytes} bytes); capping to the container memory limit" >&2
+      __dgchl_proposed_bytes=$__dgchl_limit_bytes
+    fi
+
+    export DOTNET_GCHeapHardLimit="0x$(printf '%%x' "$__dgchl_proposed_bytes")"
+    unset DOTNET_GCHeapHardLimitPercent
+    unset __dgchl_mb __dgchl_limit_bytes __dgchl_hex __dgchl_proposed_bytes __dgchl_percent_raw __dgchl_percent
+  fi
+fi
 `, filepath.Join("/home", "vcap", "deps", f.Stager.DepsIdx(), "dotnet-sdk"))
 
 	return f.Stager.WriteProfileD("startup.sh", scriptContents)

--- a/src/dotnetcore/finalize/finalize.go
+++ b/src/dotnetcore/finalize/finalize.go
@@ -189,6 +189,9 @@ if [[ "${MEMORY_LIMIT:-}" =~ ^([0-9]+)m$ ]]; then
       __dgchl_hex="${__dgchl_hex#0X}"
     fi
 
+    # DOTNET_GCHeapHardLimit is always parsed as hex here, matching .NET's own
+    # native parsing convention for this env var (a plain decimal-looking value
+    # such as "268435456" is interpreted as hex, not decimal).
     if [[ -n "${__dgchl_hex:-}" ]] && [[ "$__dgchl_hex" =~ ^[0-9a-fA-F]+$ ]]; then
       __dgchl_proposed_bytes=$(( 16#${__dgchl_hex} ))
     else

--- a/src/dotnetcore/finalize/finalize_test.go
+++ b/src/dotnetcore/finalize/finalize_test.go
@@ -3,6 +3,7 @@ package finalize_test
 import (
 	"bytes"
 	"os"
+	"os/exec"
 	"path/filepath"
 
 	"github.com/cloudfoundry/dotnet-core-buildpack/src/dotnetcore/config"
@@ -79,6 +80,116 @@ var _ = Describe("Finalize", func() {
 			It("Runs dotnet publish", func() {
 				mockCommand.EXPECT().Run(gomock.Any())
 				Expect(finalizer.DotnetPublish(stackRID)).To(Succeed())
+			})
+		})
+	})
+
+	Describe("WriteProfileD", func() {
+		var scriptPath string
+
+		BeforeEach(func() {
+			scriptPath = filepath.Join(depsDir, depsIdx, "profile.d", "startup.sh")
+		})
+
+		It("writes the ASPNETCORE_URLS and DOTNET_ROOT exports", func() {
+			Expect(finalizer.WriteProfileD()).To(Succeed())
+
+			contents, err := os.ReadFile(scriptPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(contents)).To(ContainSubstring(`export ASPNETCORE_URLS="${ASPNETCORE_URLS:-http://0.0.0.0:${PORT}}"`))
+			Expect(string(contents)).To(ContainSubstring("export DOTNET_ROOT=" + filepath.Join("/home", "vcap", "deps", depsIdx, "dotnet-sdk")))
+		})
+
+		It("writes the DOTNET_GCHeapHardLimit calculation block", func() {
+			Expect(finalizer.WriteProfileD()).To(Succeed())
+
+			contents, err := os.ReadFile(scriptPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(contents)).To(ContainSubstring("MEMORY_LIMIT"))
+			Expect(string(contents)).To(ContainSubstring("DOTNET_GCHeapHardLimit"))
+			Expect(string(contents)).To(ContainSubstring("DOTNET_GCHeapHardLimitPercent"))
+		})
+
+		runScript := func(env []string) string {
+			Expect(finalizer.WriteProfileD()).To(Succeed())
+
+			cmd := exec.Command("bash", "-c", "source "+scriptPath+` && printf '%s' "$DOTNET_GCHeapHardLimit"`)
+			cmd.Env = env
+			output, err := cmd.CombinedOutput()
+			Expect(err).NotTo(HaveOccurred())
+			return string(output)
+		}
+
+		Context("MEMORY_LIMIT is set to 1024m and no overrides are present", func() {
+			It("exports DOTNET_GCHeapHardLimit at 75 percent of the container limit", func() {
+				Expect(runScript([]string{"MEMORY_LIMIT=1024m"})).To(Equal("0x30000000"))
+			})
+		})
+
+		Context("MEMORY_LIMIT is set and DOTNET_GCHeapHardLimitPercent is set to 50", func() {
+			It("exports DOTNET_GCHeapHardLimit at the requested percentage", func() {
+				Expect(runScript([]string{"MEMORY_LIMIT=512m", "DOTNET_GCHeapHardLimitPercent=50"})).To(Equal("0x10000000"))
+			})
+		})
+
+		Context("MEMORY_LIMIT is set and DOTNET_GCHeapHardLimitPercent is invalid", func() {
+			It("falls back to the 75 percent default", func() {
+				Expect(runScript([]string{"MEMORY_LIMIT=1024m", "DOTNET_GCHeapHardLimitPercent=not-a-number"})).To(Equal("0x30000000"))
+			})
+		})
+
+		Context("MEMORY_LIMIT is set and DOTNET_GCHeapHardLimitPercent is out of range", func() {
+			It("falls back to the 75 percent default", func() {
+				Expect(runScript([]string{"MEMORY_LIMIT=1024m", "DOTNET_GCHeapHardLimitPercent=150"})).To(Equal("0x30000000"))
+			})
+		})
+
+		Context("MEMORY_LIMIT is set and DOTNET_GCHeapHardLimitPercent has a leading zero that bash would otherwise treat as invalid octal", func() {
+			It("does not abort and falls back gracefully instead of erroring", func() {
+				Expect(runScript([]string{"MEMORY_LIMIT=1024m", "DOTNET_GCHeapHardLimitPercent=08"})).To(Equal("0x51eb851"))
+			})
+		})
+
+		Context("MEMORY_LIMIT is set and DOTNET_GCHeapHardLimitPercent has a leading zero that bash would otherwise treat as valid octal", func() {
+			It("interprets the value as decimal, not octal", func() {
+				Expect(runScript([]string{"MEMORY_LIMIT=1024m", "DOTNET_GCHeapHardLimitPercent=050"})).To(Equal("0x20000000"))
+			})
+		})
+
+		Context("MEMORY_LIMIT is set to 0m", func() {
+			It("does not export DOTNET_GCHeapHardLimit", func() {
+				Expect(runScript([]string{"MEMORY_LIMIT=0m"})).To(Equal(""))
+			})
+		})
+
+		Context("MEMORY_LIMIT is set and DOTNET_GCHeapHardLimit is already set within range", func() {
+			It("respects the user-provided value", func() {
+				Expect(runScript([]string{"MEMORY_LIMIT=1024m", "DOTNET_GCHeapHardLimit=0x10000000"})).To(Equal("0x10000000"))
+			})
+		})
+
+		Context("MEMORY_LIMIT is set and DOTNET_GCHeapHardLimit exceeds it", func() {
+			It("clamps to the container memory limit and logs a warning", func() {
+				Expect(finalizer.WriteProfileD()).To(Succeed())
+
+				cmd := exec.Command("bash", "-c", "source "+scriptPath+` && printf '%s' "$DOTNET_GCHeapHardLimit"`)
+				cmd.Env = []string{"MEMORY_LIMIT=1024m", "DOTNET_GCHeapHardLimit=0x100000000"}
+				output, err := cmd.CombinedOutput()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(output)).To(ContainSubstring("WARNING: DOTNET_GCHeapHardLimit (4294967296 bytes) exceeds MEMORY_LIMIT (1073741824 bytes)"))
+				Expect(string(output)).To(HaveSuffix("0x40000000"))
+			})
+		})
+
+		Context("MEMORY_LIMIT is not set", func() {
+			It("does not export DOTNET_GCHeapHardLimit", func() {
+				Expect(runScript([]string{})).To(Equal(""))
+			})
+		})
+
+		Context("MEMORY_LIMIT does not match the expected <int>m format", func() {
+			It("does not export DOTNET_GCHeapHardLimit", func() {
+				Expect(runScript([]string{"MEMORY_LIMIT=512M"})).To(Equal(""))
 			})
 		})
 	})

--- a/src/dotnetcore/integration/init_test.go
+++ b/src/dotnetcore/integration/init_test.go
@@ -97,6 +97,7 @@ func TestIntegration(t *testing.T) {
 	suite("Default", testDefault(platform, fixtures))
 	suite("Dynatrace", testDynatrace(platform, fixtures, dynatraceDeployment.InternalURL))
 	suite("Fsharp", testFsharp(platform, fixtures))
+	suite("MemoryLimit", testMemoryLimit(platform, fixtures))
 	suite("MultipleProjects", testMultipleProjects(platform, fixtures))
 	suite("Node", testNode(platform, fixtures))
 	suite("Override", testOverride(platform, fixtures))

--- a/src/dotnetcore/integration/memory_limit_test.go
+++ b/src/dotnetcore/integration/memory_limit_test.go
@@ -1,0 +1,55 @@
+package integration_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/cloudfoundry/switchblade"
+	"github.com/sclevine/spec"
+
+	. "github.com/cloudfoundry/switchblade/matchers"
+	. "github.com/onsi/gomega"
+)
+
+func testMemoryLimit(platform switchblade.Platform, fixtures string) func(*testing.T, spec.G, spec.S) {
+	return func(t *testing.T, context spec.G, it spec.S) {
+		var (
+			Expect     = NewWithT(t).Expect
+			Eventually = NewWithT(t).Eventually
+
+			fixture string
+			name    string
+		)
+
+		it.Before(func() {
+			var err error
+			name, err = switchblade.RandomName()
+			Expect(err).NotTo(HaveOccurred())
+
+			fixture, err = switchblade.Source(filepath.Join(fixtures, "source_apps", "simple"))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		it.After(func() {
+			Expect(platform.Delete.Execute(name)).To(Succeed())
+		})
+
+		it("exports DOTNET_GCHeapHardLimit computed from MEMORY_LIMIT", func() {
+			deployment, _, err := platform.Deploy.Execute(name, fixture)
+			Expect(err).NotTo(HaveOccurred())
+
+			// 75% (the default) of the switchblade docker harness's fixed MEMORY_LIMIT=1024m
+			// (1073741824 bytes) = 805306368 bytes = 0x30000000.
+			Eventually(deployment).Should(Serve(Equal("0x30000000")).WithEndpoint("/env/dotnet-gc-heap-hard-limit"))
+		})
+
+		it("respects a caller-provided DOTNET_GCHeapHardLimitPercent", func() {
+			deployment, _, err := platform.Deploy.
+				WithEnv(map[string]string{"DOTNET_GCHeapHardLimitPercent": "50"}).
+				Execute(name, fixture)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(deployment).Should(Serve(Equal("0x20000000")).WithEndpoint("/env/dotnet-gc-heap-hard-limit"))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #1100 ("Dotnet Core Buildpack does not handle cgroup v2 memory limits correctly – app does not release memory properly").

On cgroup v2 (and "hybrid" v1+v2) Diego cells, the .NET GC can fail to detect the real container memory limit and treat memory as effectively unlimited. This is a documented, unresolved ambiguity in coreclr's own cgroup detection (see [dotnet/runtime#34334](https://github.com/dotnet/runtime/pull/34334): "It is possible to have both cgroup v1 and v2 to both be enabled on a host... this change will pick one, which may not be the correct one"). Note the cgroup hierarchy in play is a property of the **BOSH stemcell** running the Diego cell (the host kernel/OS), not the CF **stack** — `cflinuxfs4`/`cflinuxfs5` are just rootfs images bind-mounted into the app container and are orthogonal to which cgroup hierarchy the host kernel exposes; any stack can run on a Diego cell backed by any stemcell.

Rather than reimplementing cgroup-file parsing in the buildpack (which would just move the same ambiguity elsewhere), this PR has the buildpack read Cloud Foundry's own `$MEMORY_LIMIT` environment variable — which Cloud Controller computes and injects independently of any cgroup layout (see [`cloud_controller_ng/lib/cloud_controller/diego/environment.rb`](https://github.com/cloudfoundry/cloud_controller_ng/blob/main/lib/cloud_controller/diego/environment.rb)) — and uses it to explicitly set `DOTNET_GCHeapHardLimit` at container startup, bypassing the runtime's own detection entirely.

- Adds a bash calculation block to the existing `profile.d/startup.sh` script (written by `Finalizer.WriteProfileD`), which runs at every container start (not baked in at staging time, since `cf scale -m` changes `$MEMORY_LIMIT` without restaging).
- Defaults to 75% of the container memory limit (matching .NET's own documented default `GCHeapHardLimitPercent`), leaving headroom for non-GC-heap memory.
- Fully respects user overrides: setting `DOTNET_GCHeapHardLimit` or `DOTNET_GCHeapHardLimitPercent` yourself (e.g. via `cf set-env`) is honored, with a safety clamp (+ logged warning) if an explicit override would exceed the real container limit.
- No new custom environment variables introduced — reuses the native `DOTNET_GCHeapHardLimit`/`DOTNET_GCHeapHardLimitPercent` variables.
- No cgroup file parsing, no new compiled binary — pure bash inside the existing profile.d mechanism.
- Backward compatible: when `$MEMORY_LIMIT` is absent (e.g. non-CF environments), behavior is unchanged (no-op).
- The integration fixture verifies the fix via `GC.GetConfigurationVariables()["GCHeapHardLimit"]` (available since .NET 7) rather than reading back the raw environment variable, proving the CLR itself parsed and applied the value into its live GC configuration.

## Test Plan

- [x] Unit tests in `src/dotnetcore/finalize/finalize_test.go` cover the script's generated content and, via `exec.Command("bash", ...)`, its actual runtime arithmetic across all documented scenarios (default 75%, custom percent, invalid/out-of-range percent fallback, user override respected, user override clamped with warning, `MEMORY_LIMIT` absent/malformed no-op, leading-zero octal edge cases, `MEMORY_LIMIT=0m` floor). `go test -mod=vendor ./src/dotnetcore/finalize/... -run TestFinalize -v` — 18/18 passing.
- [x] `go vet -mod=vendor ./src/dotnetcore/...` clean.
- [x] Added integration test coverage (`src/dotnetcore/integration/memory_limit_test.go`) via a debug endpoint on the shared `simple` fixture app that reports `GC.GetConfigurationVariables()["GCHeapHardLimit"]`.
- [x] Ran the `MemoryLimit` integration suite end-to-end against the `switchblade` docker backend on a real deployed app (both the default-75% and `DOTNET_GCHeapHardLimitPercent=50` override cases pass, confirmed against both .NET 8 and .NET 10 SDK images).
- [ ] Full integration suite (all other suites: Default, Node, Fsharp, etc.) run against a real CF/Docker target — not run in this environment (would require building/testing unrelated language runtimes outside the scope of this change).