### PR TITLE
Fix Angular integration test staging timeout

### DIFF
--- a/src/dotnetcore/integration/init_test.go
+++ b/src/dotnetcore/integration/init_test.go
@@ -48,6 +48,9 @@ func TestIntegration(t *testing.T) {
 	format.MaxLength = 0
 	SetDefaultEventuallyTimeout(10 * time.Second)
 
+	// Set staging timeout globally for all tests to handle slow Angular builds
+	os.Setenv("CF_STAGING_TIMEOUT", "30")
+
 	root, err := filepath.Abs("./../../..")
 	Expect(err).NotTo(HaveOccurred())
 

--- a/src/dotnetcore/integration/node_test.go
+++ b/src/dotnetcore/integration/node_test.go
@@ -1,7 +1,6 @@
 package integration_test
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -33,10 +32,6 @@ func testNode(platform switchblade.Platform, fixtures string) func(*testing.T, s
 
 		context("deploying an angular app", func() {
 			it("displays a simple text homepage", func() {
-				prevTimeout := os.Getenv("CF_STAGING_TIMEOUT")
-				os.Setenv("CF_STAGING_TIMEOUT", "30")
-				defer os.Setenv("CF_STAGING_TIMEOUT", prevTimeout)
-
 				deployment, _, err := platform.Deploy.
 					Execute(name, filepath.Join(fixtures, "node_apps", "angular_dotnet"))
 				Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
The Angular app integration test was timing out at the default 15-minute CF staging timeout. The previous fix attempted to set CF_STAGING_TIMEOUT in the individual test, but this was not being properly inherited by the cf CLI subprocess.

This fix moves the CF_STAGING_TIMEOUT setting to the TestIntegration suite initialization, ensuring it's set before the switchblade platform is created and will be present in the environment for all cf CLI commands.

Changes:
- Set CF_STAGING_TIMEOUT=30 at test suite level in init_test.go
- Remove redundant per-test timeout setting from node_test.go
- Remove unused "os" import from node_test.go

Related: PR #1251, commit 50847114a
