### PR TITLE
Fix CF_STAGING_TIMEOUT by setting it at script level

### DIFF
--- a/scripts/integration.sh
+++ b/scripts/integration.sh
@@ -123,6 +123,7 @@ function specs::run() {
   buildpack_file="$(buildpack::package "1.2.3" "${cached}" "${stack}")"
 
   CF_STACK="${stack}" \
+  CF_STAGING_TIMEOUT=30 \
   BUILDPACK_FILE="${BUILDPACK_FILE:-"${buildpack_file}"}" \
   GOMAXPROCS="${GOMAXPROCS:-"${nodes}"}" \
     go test \

--- a/src/dotnetcore/integration/init_test.go
+++ b/src/dotnetcore/integration/init_test.go
@@ -48,9 +48,6 @@ func TestIntegration(t *testing.T) {
 	format.MaxLength = 0
 	SetDefaultEventuallyTimeout(10 * time.Second)
 
-	// Set staging timeout globally for all tests to handle slow Angular builds
-	os.Setenv("CF_STAGING_TIMEOUT", "30")
-
 	root, err := filepath.Abs("./../../..")
 	Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
The previous fix (commit 1a59bfaaf) attempted to set CF_STAGING_TIMEOUT using os.Setenv() in the Go test code, but this didn't work - the Angular test was still timing out at 15 minutes.

Root cause: The cf CLI subprocess was not properly inheriting the environment variable when set via os.Setenv() in the Go test code, particularly in the CI/Concourse environment.

Solution: Set CF_STAGING_TIMEOUT=30 directly in the integration.sh script where the Go tests are executed. This ensures the environment variable is available to all subprocesses including the cf CLI.

Changes:
- Added CF_STAGING_TIMEOUT=30 to scripts/integration.sh in the specs::run function
- Reverted the os.Setenv() approach from init_test.go as it was ineffective

Testing:
- Verified the Angular test was timing out at exactly 15:17 with the Go approach
- The script-level approach will make CF_STAGING_TIMEOUT available to all cf CLI invocations

Related: PR #1320, commit 1a59bfaaf