### PR TITLE
Remove Angular budget constraints for unoptimized builds

### DIFF
--- a/fixtures/node_apps/angular_dotnet/ClientApp/angular.json
+++ b/fixtures/node_apps/angular_dotnet/ClientApp/angular.json
@@ -34,18 +34,6 @@
           },
           "configurations": {
             "production": {
-              "budgets": [
-                {
-                  "type": "initial",
-                  "maximumWarning": "500kb",
-                  "maximumError": "1mb"
-                },
-                {
-                  "type": "anyComponentStyle",
-                  "maximumWarning": "2kb",
-                  "maximumError": "4kb"
-                }
-              ],
               "fileReplacements": [
                 {
                   "replace": "src/environments/environment.ts",


### PR DESCRIPTION
When using `--optimization=false`, the bundle size is ~2.5MB which exceeds the 1MB budget limit. Since this is an integration test fixture and not a production app, remove the budget constraints entirely.